### PR TITLE
WASP-43 b directory

### DIFF
--- a/notebooks/HST_WFC3.ipynb
+++ b/notebooks/HST_WFC3.ipynb
@@ -68,7 +68,7 @@
     "exo_dict['star']['mag']      = 9.397                # H magnitude of the system\n",
     "#WASP-43b\n",
     "exo_dict['planet']['type']    = 'user'               # user specified inputs\n",
-    "exo_dict['planet']['exopath'] = '/Users/nbatalh1/Desktop/JWST/pandexo/notebooks/WASP43b-Eclipse_Spectrum.txt' # filename for model spectrum\n",
+    "exo_dict['planet']['exopath'] = jdi.os.getcwd()+'/WASP43b-Eclipse_Spectrum.txt' # filename for model spectrum\n",
     "exo_dict['planet']['w_unit']  = 'um'                 # wavelength unit\n",
     "exo_dict['planet']['f_unit']  = 'fp/f*'              # flux ratio unit (can also put \"rp^2/r*^2\")\n",
     "exo_dict['planet']['depth']   = 4.0e-3               # flux ratio\n",


### PR DESCRIPTION
I changed the example WASP 43 b spectrum reference to the current directory instead of a specific path.