### PR TITLE
Fix Infinite Loop in bin_wave_to_R

### DIFF
--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -217,8 +217,8 @@ def bin_wave_to_R(w, R):
             if newR < R:
                 tracker = w[ind]+dlambda/2.0
                 wave +=[tracker]
-                ind = (np.abs(w-tracker)).argmin()
-                i = ind
+                ind = i
+                i+=1
             else:            
                 i+=1    
         else:


### PR DESCRIPTION
This fixed for me an infinite while loop within justplotit.bin_wave_to_R because it was rewinding the indices forever. I now have "ind" reset to "i" when it has accepted a value and progress to "i" by +1, so it doesn't create an infinite resolving power step in the next iteration.