### PR TITLE
Python3 print friendly

### DIFF
--- a/pandexo/engine/ComputeZ.py
+++ b/pandexo/engine/ComputeZ.py
@@ -285,7 +285,7 @@ def computeJac(molDict):
             
             flag[j] = 0
             
-            #print i, j, val, type(val)
+            #print(i, j, val, type(val))
             J[i,j] = float(val)
 
     return J

--- a/pandexo/engine/justdoit.py
+++ b/pandexo/engine/justdoit.py
@@ -27,8 +27,8 @@ ALL = {"WFC3 G141":False,
 def print_instruments():
     """Prints a list of the possible instrument templates to load
     """
-    print "Choose from the following:"
-    print ALL.keys()
+    print("Choose from the following:")
+    print(ALL.keys())
     return
 
 def load_exo_dict():
@@ -225,7 +225,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
 
     #single instrument mode with dictionary input OR single planet 
     if type(inst) == dict: 
-        print "Running Single Case w/ User Instrument Dict"
+        print("Running Single Case w/ User Instrument Dict")
         results =wrapper({"pandeia_input": inst , "pandexo_input":exo})
         if output_file == '':
             output_file = 'singlerun.p'
@@ -237,8 +237,8 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         if type(inst) != list: 
             raise ValueError
     except ValueError:
-        print 'Instrument input is not dict so must be list'
-        print 'Enter in format ["NIRSpec G140M"] or ["NIRISS SOSS","MIRI LRS"]' 
+        print('Instrument input is not dict so must be list')
+        print('Enter in format ["NIRSpec G140M"] or ["NIRISS SOSS","MIRI LRS"]')
         return    
          
     #single instrument mode and single planet OR several planets  
@@ -247,7 +247,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         
         #start case of no parameter space run 
         if isinstance(param_space, (float, int)) or isinstance(param_range, (float, int)):
-            print "Running Single Case for: " + inst[0]
+            print("Running Single Case for: " + inst[0])
             inst_dict = load_mode_dict(inst[0])
             results =wrapper({"pandeia_input": inst_dict , "pandexo_input":exo})
             if output_file == '':
@@ -256,7 +256,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
             return results
          
         #if there are parameters to cycle through this will run
-        print "Running through exo parameters in parallel: " + param_space 
+        print("Running through exo parameters in parallel: " + param_space)
         #run the above function in parallel 
         results = Parallel(n_jobs=num_cores)(delayed(run_param_space)(i,exo,inst[0],param_space) for i in param_range)
         
@@ -269,7 +269,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         return results
         
     #run several different instrument modes and single planet
-    print "Running select instruments" 
+    print("Running select instruments")
     if len(inst)>1:
         
         results = Parallel(n_jobs=num_cores)(delayed(run_inst_space)(i, exo) for i in inst)
@@ -283,7 +283,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
             
     #cycle through all options  
     elif inst[0].lower() == 'run all':
-        print "Running through all instruments"  
+        print("Running through all instruments")
         results = Parallel(n_jobs=num_cores)(delayed(run_inst_space)(i, exo) for i in ALL.keys())
     
         #Default dump all results [an array of dictionaries] into single file

--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -131,7 +131,7 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
             y = sim_spec
             err = np.sqrt(vout+vin)/out
         else: 
-            print "Something went wrong. Cannot enter both resolution and ask to bin to new wave"
+            print("Something went wrong. Cannot enter both resolution and ask to bin to new wave")
             return
             
         #create error bars for Bokeh's multi_line
@@ -202,7 +202,7 @@ def bin_wave_to_R(w, R):
     --------
     
     >>> newwave = bin_wave_to_R(np.linspace(1,2,1000), 10)
-    >>> print len(newwave)
+    >>> print(len(newwave))
     11
     """
     wave = []

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -278,7 +278,7 @@ def compute_maxexptime_per_int(pandeia_input, sat_level):
     --------
     
     >>> max_time = compute_maxexptime_per_int(pandeia_input, 50000.0)
-    >>> print max_time 
+    >>> print(max_time)
     12.0
     """
     
@@ -339,7 +339,7 @@ def compute_timing(m,transit_duration,expfact_out,noccultations):
     Examples
     --------
     >>> timing, flags = compute_timing(m, 2*60.0*60.0, 1.0, 1.0)
-    >>> print timing.keys()
+    >>> print(timing.keys())
     ['Number of Transits', 'Num Integrations Out of Transit', 'Num Integrations In Transit', 
     'APT: Num Groups per Integration', 'Seconds per Frame', 'Observing Efficiency (%)', 'On Source Time(sec)', 
     'Exposure Time Per Integration (secs)', 'Reset time Plus 30 min TA time (hrs)',
@@ -625,7 +625,7 @@ def add_noise_floor(noise_floor, wave_bin, error_spec):
     >>> wave = np.linspace(1,2.7,10)
     >>> error = np.zeros(10)+1e-6
     >>> newerror = add_noise_floor(20, wave, error)
-    >>> print newerror
+    >>> print(newerror)
     [  2.00000000e-05   2.00000000e-05   2.00000000e-05   2.00000000e-05
        2.00000000e-05   2.00000000e-05   2.00000000e-05   2.00000000e-05
        2.00000000e-05   2.00000000e-05]
@@ -667,7 +667,7 @@ def bin_wave_to_R(w, R):
     --------
     
     >>> newwave = bin_wave_to_R(np.linspace(1,2,1000), 10)
-    >>> print len(newwave)
+    >>> print(len(newwave))
     11
     """
     wave = []

--- a/pandexo/engine/pandexo.py
+++ b/pandexo/engine/pandexo.py
@@ -37,4 +37,4 @@ def wrapper(dictinput):
     elif telescope=='wfirst':
         return     
     else:
-        print "INVALID TELESCOPE. PandExo only accepts: jwst, hst, wfirst"
+        print("INVALID TELESCOPE. PandExo only accepts: jwst, hst, wfirst")

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -323,7 +323,7 @@ class CalculationNewHandler(BaseHandler):
                 if exodata["planet"]["w_unit"] == 'sec':
                     exodata["planet"]["transit_duration"] = 0.0
                 else: 
-                    print "Need to give transit duration"
+                    print("Need to give transit duration")
                     raise 
                 
             #noise floor, set to 0.0 of no values are input        


### PR DESCRIPTION
I went through all of the .py files and searched for any Python2 print command structures (with a space) and converted them to Python3 print command structures (with parentheses). 

This was very straightforward and should be backwards compatible with Python2 sessions.