### PR TITLE
Python3 pickle friendly

### DIFF
--- a/pandexo/engine/hst.py
+++ b/pandexo/engine/hst.py
@@ -568,7 +568,7 @@ def create_out_div(input_dict,minphase,maxphase):
         html rendered table
     """
     input_dict['Start observations between orbital phases'] = str(minphase)+'-'+str(maxphase)
-    input_div = pd.DataFrame(input_dict.items(), columns=['Component', 'Values']).to_html().encode()
+    input_div = pd.DataFrame(input_dict.items(), columns=['Component', 'Values']).to_html()#.encode()
     input_div = '<table class="table table-striped"> \n' + input_div[36:len(input_div)]
     return input_div
     

--- a/pandexo/engine/justdoit.py
+++ b/pandexo/engine/justdoit.py
@@ -229,7 +229,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         results =wrapper({"pandeia_input": inst , "pandexo_input":exo})
         if output_file == '':
             output_file = 'singlerun.p'
-        if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'w'))
+        if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'wb'))
         return results
 
     #make sure inst is in list format.. makes my life so much easier
@@ -252,7 +252,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
             results =wrapper({"pandeia_input": inst_dict , "pandexo_input":exo})
             if output_file == '':
                 output_file = 'singlerun.p'
-            if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'w'))
+            if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'wb'))
             return results
          
         #if there are parameters to cycle through this will run
@@ -265,7 +265,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         if output_file == '':
             output_file = param_space + '.p'
 
-        if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'w'))
+        if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'wb'))
         return results
         
     #run several different instrument modes and single planet
@@ -278,7 +278,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         #and return results immediately to user
         if output_file == '':
             output_file =  'instrument_run.p'
-        if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'w'))
+        if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'wb'))
         return results
             
     #cycle through all options  
@@ -290,5 +290,5 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         #and return results immediately to user
         if output_file == '':
             output_file =  'instrument_run.p'
-        if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'w'))
+        if save_file: pkl.dump(results, open(os.path.join(output_path,output_file),'wb'))
         return results


### PR DESCRIPTION
Python2 pickle formats write as bytestrings, but Python3 reads them as strings. To read a Python2 pickle in Python3, we must first read in the file as 'rb'. such as 

`pkl.load(filename, 'rb')`

and store them as 

`pkl.dump(filename, 'wb')`

In the reading case -- not an issue here -- we must set the pickle encoding as 'latin1' for it to read/write between Python2 and Python3. I got all of this information from

http://stackoverflow.com/questions/28218466/unpickling-a-python-2-object-with-python-3

------
In addition, in the file "hst.py" there was a `pandas` command that converted a DataFrame to html (`.to_html()`) and then 'encoded' it (`.encode()`).  

In Python3, the encoding line

`input_div = pd.DataFrame(input_dict.items(), columns=['Component', 'Values']).to_html()#.encode()`

converts the string to a bytestring, which then flags an error on the line below

`input_div = '<table class="table table-striped"> \n' + input_div[36:len(input_div)]`

because Python3 cannot concatenate strings with bytestrings.  To avoid this, I commented out the `.encode()` section on line 571, which cleared the error and I was able to continue with the tutorial notebook "HST_WFC3.ipynb"

------
Because both issues involve and "encoding", I would imagine that they are the same underlying Python2 vs Python3 issue; but the application is vastly different. Either way, this PR allows the "HST_WFC3.ipynb" tutorial notebook to operate smoothy with Python3