### PR TITLE
jpi fraction

### DIFF
--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -89,9 +89,12 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
         else:
             fac =  1.0
 
-        out  = dict['RawData']['electrons_out']* num_tran/ntran_old
+        fraction = (dict['timing']['Num Integrations In Transit'] /
+                    dict['timing']['Num Integrations Out of Transit'])
+
+        out  = dict['RawData']['electrons_out']* num_tran/ntran_old * fraction
         inn  = dict['RawData']['electrons_in'] * num_tran/ntran_old
-        vout = dict['RawData']['var_out']      * num_tran/ntran_old
+        vout = dict['RawData']['var_out']      * num_tran/ntran_old * fraction
         vin  = dict['RawData']['var_in']       * num_tran/ntran_old
 
         if R is not False:

--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -3,55 +3,55 @@ from bokeh.io import output_file as outputfile
 import pickle as pk
 import numpy as np
 from bokeh.layouts import row
-def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', output_file = 'data.html',legend = False, 
+def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', output_file = 'data.html',legend = False,
         R=False,  num_tran = False, plot_width=800, plot_height=400,x_range=[1,10]):
     """Plots 1d simulated spectrum and rebin or rescale for more transits
-    
-    Plots 1d data points with model in the background (if wanted). Designed to read in exact 
-    output of run_pandexo. 
-    
-    Parameters 
+
+    Plots 1d data points with model in the background (if wanted). Designed to read in exact
+    output of run_pandexo.
+
+    Parameters
     ----------
     result_dict : dict or list of dict
-        Dictionary from pandexo output. If parameter space was run in run_pandexo 
-        make sure to restructure the input as a list of dictionaries without they key words 
-        that run_pandexo assigns. 
-    model : bool 
-        (Optional) True is default. True plots model, False does not plot model     
+        Dictionary from pandexo output. If parameter space was run in run_pandexo
+        make sure to restructure the input as a list of dictionaries without they key words
+        that run_pandexo assigns.
+    model : bool
+        (Optional) True is default. True plots model, False does not plot model
     title : str
-        (Optional) Title of plot. Default is "Model + Data + Error Bars".  
-    output_file : str 
-        (Optional) name of html file for you bokeh plot. After bokeh plot is rendered you will 
-        have the option to save as png. 
-    legend : bool 
-        (Optional) Default is False. True, plots legend. 
-    R : float 
-        (Optional) Rebin data from native instrument resolution to specified resolution. Dafult is False, 
-        no binning. 
+        (Optional) Title of plot. Default is "Model + Data + Error Bars".
+    output_file : str
+        (Optional) name of html file for you bokeh plot. After bokeh plot is rendered you will
+        have the option to save as png.
+    legend : bool
+        (Optional) Default is False. True, plots legend.
+    R : float
+        (Optional) Rebin data from native instrument resolution to specified resolution. Dafult is False,
+        no binning.
     num_tran : float
         (Optional) Scales data by number of transits to improve error by sqrt(`num_trans`)
-    plot_width : int 
+    plot_width : int
         (Optional) Sets the width of the plot. Default = 800
-    plot_height : int 
-        (Optional) Sets the height of the plot. Default = 400 
+    plot_height : int
+        (Optional) Sets the height of the plot. Default = 400
     x_range : list of int
         (Optional) Sets x range of plot. Default = [1,10]
 
     Returns
     -------
-    x,y,e : list of arrays 
-        Returns wave axis, spectrum and associated error in list format. x[0] will be correspond 
-        to the first dictionary input, x[1] to the second, etc. 
-        
+    x,y,e : list of arrays
+        Returns wave axis, spectrum and associated error in list format. x[0] will be correspond
+        to the first dictionary input, x[1] to the second, etc.
+
     Examples
     --------
-    
-    >>> jwst_1d_spec(result_dict, num_tran = 3, R = 35) #for a single plot 
-    
-    If you wanted to save each of the axis that were being plotted: 
-    
-    >>> x,y,e = jwst_1d_data([result_dict1, result_dict2], model=False, num_tran = 5, R = 100) #for multiple 
-    
+
+    >>> jwst_1d_spec(result_dict, num_tran = 3, R = 35) #for a single plot
+
+    If you wanted to save each of the axis that were being plotted:
+
+    >>> x,y,e = jwst_1d_data([result_dict1, result_dict2], model=False, num_tran = 5, R = 100) #for multiple
+
     See Also
     --------
     jwst_noise, jwst_1d_bkg, jwst_1d_flux, jwst_1d_snr, jwst_2d_det, jwst_2d_sat
@@ -64,29 +64,29 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
     outputfile(output_file)
     colors = ['black','blue','red','orange','yellow','purple','pink','cyan','grey','brown']
     #make sure its iterable
-    if type(result_dict) != list: 
+    if type(result_dict) != list:
         result_dict = [result_dict]
-        
+
     if type(legend)!=bool:
         legend_keys = legend
         legend = True
         if type(legend_keys) != list:
             legend_keys = [legend_keys]
-      
-    i = 0     
-    for dict in result_dict: 
+
+    i = 0
+    for dict in result_dict:
         ntran_old = dict['timing']['Number of Transits']
-        #remove any nans 
+        #remove any nans
         y = dict['FinalSpectrum']['spectrum_w_rand']
         x = dict['FinalSpectrum']['wave'][~np.isnan(y)]
         err = dict['FinalSpectrum']['error_w_floor'][~np.isnan(y)]
         y = y[~np.isnan(y)]
 
-        
-        if (R == False) & (num_tran == False): 
-            x=x 
-            y=y 
-        elif (R != False) & (num_tran != False):     
+
+        if (R == False) & (num_tran == False):
+            x=x
+            y=y
+        elif (R != False) & (num_tran != False):
             new_wave = bin_wave_to_R(x, R)
             out = uniform_tophat_sum(new_wave,x, dict['RawData']['electrons_out']*num_tran/ntran_old)
             inn = uniform_tophat_sum(new_wave,x, dict['RawData']['electrons_in']*num_tran/ntran_old)
@@ -97,11 +97,11 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
             else:
                 fac = 1.0
             rand_noise = np.sqrt((vin+vout))*(np.random.randn(len(new_wave)))
-            sim_spec = fac*(out-inn + rand_noise)/out 
+            sim_spec = fac*(out-inn + rand_noise)/out
             x = new_wave
             y = sim_spec
             err = np.sqrt(vout+vin)/out
-        elif (R == False) & (num_tran != False):     
+        elif (R == False) & (num_tran != False):
             out = dict['RawData']['electrons_out']*num_tran/ntran_old
             inn = dict['RawData']['electrons_in']*num_tran/ntran_old
             vout = dict['RawData']['var_out']*num_tran/ntran_old
@@ -111,11 +111,11 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
             else:
                 fac = 1.0
             rand_noise = np.sqrt((vin+vout))*(np.random.randn(len(x)))
-            sim_spec = fac*(out-inn + rand_noise)/out 
+            sim_spec = fac*(out-inn + rand_noise)/out
             x = x
             y = sim_spec
             err = np.sqrt(vout+vin)/out
-        elif (R != False) & (num_tran == False):     
+        elif (R != False) & (num_tran == False):
             new_wave = bin_wave_to_R(x, R)
             out = uniform_tophat_sum(new_wave,x, dict['RawData']['electrons_out'])
             inn = uniform_tophat_sum(new_wave,x, dict['RawData']['electrons_in'])
@@ -126,14 +126,14 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
             else:
                 fac = 1.0
             rand_noise = np.sqrt((vin+vout))*(np.random.randn(len(new_wave)))
-            sim_spec = fac*(out-inn + rand_noise)/out 
+            sim_spec = fac*(out-inn + rand_noise)/out
             x = new_wave
             y = sim_spec
             err = np.sqrt(vout+vin)/out
-        else: 
+        else:
             print("Something went wrong. Cannot enter both resolution and ask to bin to new wave")
             return
-            
+
         #create error bars for Bokeh's multi_line
         y_err = []
         x_err = []
@@ -141,7 +141,7 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
             np.array(x_err.append((px, px)))
             np.array(y_err.append((py - yerr, py + yerr)))
         #initialize Figure
-        if i == 0: 
+        if i == 0:
             #Define units for x and y axis
             y_axis_label = dict['input']['Primary/Secondary']
 
@@ -153,61 +153,61 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
                 x_range = [min(x), max(x)]
             else:
                 x_axis_label='Wavelength [microns]'
-            
+
             ylims = [min(dict['OriginalInput']['model_spec'])- 0.1*min(dict['OriginalInput']['model_spec']),
                  0.1*max(dict['OriginalInput']['model_spec'])+max(dict['OriginalInput']['model_spec'])]
             xlims = [min(x), max(x)]
-         
-            fig1d = Figure(x_range=x_range, y_range = ylims, 
+
+            fig1d = Figure(x_range=x_range, y_range = ylims,
                plot_width = plot_width, plot_height =plot_height,title=title,x_axis_label=x_axis_label,
               y_axis_label = y_axis_label, tools=TOOLS, background_fill_color = 'white')
-        
-              
-        #plot model, data, and errors 
+
+
+        #plot model, data, and errors
         if model:
             mxx = dict['OriginalInput']['model_wave']
             myy = dict['OriginalInput']['model_spec']
-            
+
             my = uniform_tophat_mean(x, mxx,myy)
             fig1d.line(x,my, color='black',alpha=0.2, line_width = 4)
-        if legend: 
+        if legend:
             fig1d.circle(x, y, color=colors[i], legend = legend_keys[i])
-        else: 
+        else:
             fig1d.circle(x, y, color=colors[i])
         outx += [x]
         outy += [y]
         oute += [err]
         fig1d.multi_line(x_err, y_err,color=colors[i])
-        i += 1 
+        i += 1
     show(fig1d)
     return outx,outy,oute
 
-    
+
 def bin_wave_to_R(w, R):
     """Creates new wavelength axis at specified resolution
-    
+
     Parameters
     ----------
     w : list of float or numpy array of float
-        Wavelength axis to be rebinned 
-    R : float or int 
-        Resolution to bin axis to 
-    
+        Wavelength axis to be rebinned
+    R : float or int
+        Resolution to bin axis to
+
     Returns
     -------
     list of float
         New wavelength axis at specified resolution
-    
+
     Examples
     --------
-    
+
     >>> newwave = bin_wave_to_R(np.linspace(1,2,1000), 10)
     >>> print(len(newwave))
     11
     """
     wave = []
     tracker = min(w)
-    i = 1 
+    i = 1
     ind= 0
     firsttime = True
     while(tracker<max(w)):
@@ -218,7 +218,7 @@ def bin_wave_to_R(w, R):
                 tracker = w[ind]
                 wave += [tracker]
                 ind += 1
-                i += 1 
+                i += 1
                 firsttime = True
             elif newR < R:
                 tracker = w[ind]+dlambda/2.0
@@ -227,8 +227,8 @@ def bin_wave_to_R(w, R):
                 i = ind+1
                 firsttime = True
             else:
-                firsttime = False            
-                i+=1    
+                firsttime = False
+                i+=1
         else:
             tracker = max(w)
             wave += [tracker]
@@ -236,25 +236,25 @@ def bin_wave_to_R(w, R):
 
 def uniform_tophat_sum(xnew,x, y):
     """Adapted from Mike R. Line to rebin spectra
-    
-    Takes sum of group of points in bin of wave points 
+
+    Takes sum of group of points in bin of wave points
     Parameters
     ----------
     xnew : list of float or numpy array of float
-        New wavelength grid to rebin to 
-    x : list of float or numpy array of float 
-        Old wavelength grid to get rid of 
-    y : list of float or numpy array of float 
-        New rebinned y axis 
-    
+        New wavelength grid to rebin to
+    x : list of float or numpy array of float
+        Old wavelength grid to get rid of
+    y : list of float or numpy array of float
+        New rebinned y axis
+
     Returns
     -------
-    array of floats 
+    array of floats
         new y axis
 
-    Examples 
+    Examples
     --------
-        
+
     >>> oldgrid = np.linspace(1,3,100)
     >>> y = np.zeros(100)+10.0
     >>> newy = uniform_tophat_sum(np.linspace(2,3,3), oldgrid, y)
@@ -265,8 +265,8 @@ def uniform_tophat_sum(xnew,x, y):
     szmod=xnew.shape[0]
     delta=np.zeros(szmod)
     ynew=np.zeros(szmod)
-    delta[0:-1]=xnew[1:]-xnew[:-1]  
-    delta[szmod-1]=delta[szmod-2] 
+    delta[0:-1]=xnew[1:]-xnew[:-1]
+    delta[szmod-1]=delta[szmod-2]
     #pdb.set_trace()
     for i in range(szmod-1):
         i=i+1
@@ -278,25 +278,25 @@ def uniform_tophat_sum(xnew,x, y):
 
 def uniform_tophat_mean(xnew,x, y):
     """Adapted from Mike R. Line to rebin spectra
-    
+
     Takes average of group of points in bin
-    
+
     Parameters
     ----------
     xnew : list of float or numpy array of float
-        New wavelength grid to rebin to 
-    x : list of float or numpy array of float 
-        Old wavelength grid to get rid of 
-    y : list of float or numpy array of float 
-        New rebinned y axis 
+        New wavelength grid to rebin to
+    x : list of float or numpy array of float
+        Old wavelength grid to get rid of
+    y : list of float or numpy array of float
+        New rebinned y axis
 
     Returns
     -------
-    array of floats 
-        new y axis 
+    array of floats
+        new y axis
 
-    Examples 
-    -------- 
+    Examples
+    --------
     >>> oldgrid = np.linspace(1,3,100)
     >>> y = np.zeros(100)+10.0
     >>> newy = uniform_tophat_sum(np.linspace(2,3,3), oldgrid, y)
@@ -307,8 +307,8 @@ def uniform_tophat_mean(xnew,x, y):
     szmod=xnew.shape[0]
     delta=np.zeros(szmod)
     ynew=np.zeros(szmod)
-    delta[0:-1]=xnew[1:]-xnew[:-1]  
-    delta[szmod-1]=delta[szmod-2] 
+    delta[0:-1]=xnew[1:]-xnew[:-1]
+    delta[szmod-1]=delta[szmod-2]
     #pdb.set_trace()
     for i in range(szmod-1):
         i=i+1
@@ -318,33 +318,33 @@ def uniform_tophat_mean(xnew,x, y):
     ynew[0]=np.mean(y[loc])
     return ynew
 
-def jwst_1d_flux(result_dict, plot=True, output_file= 'flux.html'): 
+def jwst_1d_flux(result_dict, plot=True, output_file= 'flux.html'):
     """Plot flux rate in e/s
-    
+
     Parameters
     ----------
     result_dict : dict
-        Dictionary from pandexo output. If parameter space was run in run_pandexo 
-        make sure to restructure the input as a list of dictionaries without they key words 
-        that run_pandexo assigns. 
-    plot : bool 
+        Dictionary from pandexo output. If parameter space was run in run_pandexo
+        make sure to restructure the input as a list of dictionaries without they key words
+        that run_pandexo assigns.
+    plot : bool
         (Optional) True renders plot, Flase does not. Default=True
     output_file : str
-        (Optional) Default = 'flux.html'    
+        (Optional) Default = 'flux.html'
     Return
     ------
     x : numpy array
         micron
     y : numpy array
         1D flux rate in electrons/s
-        
+
     See Also
     --------
     jwst_1d_spec, jwst_1d_bkg, jwst_noise, jwst_1d_snr, jwst_2d_det, jwst_2d_sat
     """
     TOOLS = "pan,wheel_zoom,box_zoom,resize,reset,save"
     out = result_dict['PandeiaOutTrans']
-    
+
     # Flux 1d
     x, y = out['1d']['extracted_flux']
     x = x[~np.isnan(y)]
@@ -355,26 +355,26 @@ def jwst_1d_flux(result_dict, plot=True, output_file= 'flux.html'):
                          y_axis_label='Flux (e/s)', title="Out of Transit Flux Rate",
                          plot_width=800, plot_height=300)
     plot_flux_1d1.line(x, y, line_width = 4, alpha = .7)
-    
-    if plot: 
+
+    if plot:
         outputfile(output_file)
         show(plot_flux_1d1)
     return x,y
-    
-def jwst_1d_snr(result_dict, plot=True, output_file='snr.html'): 
+
+def jwst_1d_snr(result_dict, plot=True, output_file='snr.html'):
     """Plot SNR
-    
+
     Parameters
     ----------
     result_dict : dict
-        Dictionary from pandexo output. If parameter space was run in run_pandexo 
-        make sure to restructure the input as a list of dictionaries without they key words 
-        that run_pandexo assigns. 
-    plot : bool 
+        Dictionary from pandexo output. If parameter space was run in run_pandexo
+        make sure to restructure the input as a list of dictionaries without they key words
+        that run_pandexo assigns.
+    plot : bool
         (Optional) True renders plot, Flase does not. Default=True
     output_file : str
-        (Optional) Default = 'snr.html'   
-                
+        (Optional) Default = 'snr.html'
+
     Return
     ------
     x : numpy array
@@ -385,7 +385,7 @@ def jwst_1d_snr(result_dict, plot=True, output_file='snr.html'):
     See Also
     --------
     jwst_1d_bkg, jwst_noise, jwst_1d_flux, jwst_1d_spec, jwst_2d_det, jwst_2d_sat
-    """    
+    """
     TOOLS = "pan,wheel_zoom,box_zoom,resize,reset,save"
     # Flux 1d
     x= result_dict['RawData']['wave']
@@ -398,25 +398,25 @@ def jwst_1d_snr(result_dict, plot=True, output_file='snr.html'):
                          y_axis_label='SNR', title="SNR Out of Trans",
                          plot_width=800, plot_height=300)
     plot_snr_1d1.line(x, y, line_width = 4, alpha = .7)
-    if plot: 
+    if plot:
         outputfile(output_file)
         show(plot_snr_1d1)
     return x,y
 
 def jwst_1d_bkg(result_dict, plot=True, output_file='bkg.html'):
     """Plot background
-    
+
     Parameters
     ----------
     result_dict : dict
-        Dictionary from pandexo output. If parameter space was run in run_pandexo 
-        make sure to restructure the input as a list of dictionaries without they key words 
-        that run_pandexo assigns. 
-    plot : bool 
+        Dictionary from pandexo output. If parameter space was run in run_pandexo
+        make sure to restructure the input as a list of dictionaries without they key words
+        that run_pandexo assigns.
+    plot : bool
         (Optional) True renders plot, Flase does not. Default=True
     output_file : str
         (Optional) Default = bkt.html
-    
+
     Return
     ------
     x : numpy array
@@ -427,7 +427,7 @@ def jwst_1d_bkg(result_dict, plot=True, output_file='bkg.html'):
     See Also
     --------
     jwst_1d_spec, jwst_noise, jwst_1d_flux, jwst_1d_snr, jwst_2d_det, jwst_2d_sat
-    """    
+    """
     TOOLS = "pan,wheel_zoom,box_zoom,resize,reset,save"
     # BG 1d
     out = result_dict['PandeiaOutTrans']
@@ -439,21 +439,21 @@ def jwst_1d_bkg(result_dict, plot=True, output_file='bkg.html'):
                          y_axis_label='Flux (e/s)', title="Background",
                          plot_width=800, plot_height=300)
     plot_bg_1d1.line(x, y, line_width = 4, alpha = .7)
-    if plot: 
+    if plot:
         outputfile(output_file)
         show(plot_bg_1d1)
     return x,y
-    
-def jwst_noise(result_dict, plot=True, output_file= 'noise.html'): 
+
+def jwst_noise(result_dict, plot=True, output_file= 'noise.html'):
     """Plot background
-    
+
     Parameters
     ----------
     result_dict : dict
-        Dictionary from pandexo output. If parameter space was run in run_pandexo 
-        make sure to restructure the input as a list of dictionaries without they key words 
-        that run_pandexo assigns. 
-    plot : bool 
+        Dictionary from pandexo output. If parameter space was run in run_pandexo
+        make sure to restructure the input as a list of dictionaries without they key words
+        that run_pandexo assigns.
+    plot : bool
         (Optional) True renders plot, Flase does not. Default=True
     output_file : str
         (Optional) Default = 'noise.html'
@@ -467,13 +467,13 @@ def jwst_noise(result_dict, plot=True, output_file= 'noise.html'):
     See Also
     --------
     jwst_1d_spec, jwst_1d_bkg, jwst_1d_flux, jwst_1d_snr, jwst_2d_det, jwst_2d_sat
-    """  
+    """
     TOOLS = "pan,wheel_zoom,box_zoom,resize,reset,save"    #saturation
 
     x = result_dict['FinalSpectrum']['wave']
     y = result_dict['FinalSpectrum']['error_w_floor']*1e6
     x = x[~np.isnan(y)]
-    y = y[~np.isnan(y)]    
+    y = y[~np.isnan(y)]
     ymed = np.median(y)
 
 
@@ -483,26 +483,26 @@ def jwst_noise(result_dict, plot=True, output_file= 'noise.html'):
                          plot_width=800, plot_height=300, y_range = [0,2.0*ymed])
     ymed = np.median(y)
     plot_noise_1d1.circle(x, y, line_width = 4, alpha = .7)
-    if plot: 
+    if plot:
         outputfile(output_file)
         show(plot_noise_1d1)
     return x,y
-    
-def jwst_2d_det(result_dict, plot=True, output_file='det2d.html'): 
+
+def jwst_2d_det(result_dict, plot=True, output_file='det2d.html'):
     """Plot 2d detector image
-    
+
     Parameters
     ----------
     result_dict : dict
-        Dictionary from pandexo output. If parameter space was run in run_pandexo 
-        make sure to restructure the input as a list of dictionaries without they key words 
-        that run_pandexo assigns. 
-    
-    plot : bool 
+        Dictionary from pandexo output. If parameter space was run in run_pandexo
+        make sure to restructure the input as a list of dictionaries without they key words
+        that run_pandexo assigns.
+
+    plot : bool
         (Optional) True renders plot, Flase does not. Default=True
     output_file : str
-        (Optional) Default = 'det2d.html'    
-    
+        (Optional) Default = 'det2d.html'
+
     Return
     ------
     numpy array
@@ -516,15 +516,15 @@ def jwst_2d_det(result_dict, plot=True, output_file='det2d.html'):
     out = result_dict['PandeiaOutTrans']
     data = out['2d']['detector']
 
-    
+
     xr, yr = data.shape
-    
+
     plot_detector_2d = Figure(tools="pan,wheel_zoom,box_zoom,resize,reset,hover,save",
                          x_range=[0, yr], y_range=[0, xr],
                          x_axis_label='Pixel', y_axis_label='Spatial',
                          title="2D Detector Image",
                         plot_width=800, plot_height=300)
-    
+
     plot_detector_2d.image(image=[data], x=[0], y=[0], dh=[xr], dw=[yr],
                       palette="Spectral11")
     if plot:
@@ -533,21 +533,21 @@ def jwst_2d_det(result_dict, plot=True, output_file='det2d.html'):
     return data
 
 
-def jwst_2d_sat(result_dict, plot=True, output_file='sat2d.html'): 
+def jwst_2d_sat(result_dict, plot=True, output_file='sat2d.html'):
     """Plot 2d saturation profile
-    
+
     Parameters
     ----------
-    result_dict : dict 
-        Dictionary from pandexo output. If parameter space was run in run_pandexo 
-        make sure to restructure the input as a list of dictionaries without they key words 
-        that run_pandexo assigns. 
-    
-    plot : bool 
+    result_dict : dict
+        Dictionary from pandexo output. If parameter space was run in run_pandexo
+        make sure to restructure the input as a list of dictionaries without they key words
+        that run_pandexo assigns.
+
+    plot : bool
         (Optional) True renders plot, Flase does not. Default=True
     output_file : str
-        (Optional) Default = 'sat2d.html'    
-    
+        (Optional) Default = 'sat2d.html'
+
     Return
     ------
     numpy array
@@ -566,29 +566,29 @@ def jwst_2d_sat(result_dict, plot=True, output_file='sat2d.html'):
                          x_axis_label='Pixel', y_axis_label='Spatial',
                          title="Saturation",
                         plot_width=800, plot_height=300)
-    
+
     plot_sat_2d.image(image=[data], x=[0], y=[0], dh=[xr], dw=[yr],
                       palette="Spectral11")
     if plot:
         outputfile(output_file)
         show(plot_sat_2d)
     return data
-    
+
 def hst_spec(result_dict, plot=True, output_file ='hstspec.html', model = True):
-    """Plot 1d spec with error bars for hst 
-    
+    """Plot 1d spec with error bars for hst
+
     Parameters
     ----------
-    result_dict : dict 
+    result_dict : dict
         Dictionary from pandexo output.
-    
-    plot : bool 
+
+    plot : bool
         (Optional) True renders plot, False does not. Default=True
-    model : bool 
+    model : bool
         (Optional) Plot model under data. Default=True
     output_file : str
-        (Optional) Default = 'hstspec.html'    
-    
+        (Optional) Default = 'hstspec.html'
+
     Return
     ------
     x : numpy array
@@ -600,7 +600,7 @@ def hst_spec(result_dict, plot=True, output_file ='hstspec.html', model = True):
     modelx : numpy array
         micron
     modely : numpy array
-        1D spec fp/f* or rp^2/r*^2        
+        1D spec fp/f* or rp^2/r*^2
     See Also
     --------
     hst_time
@@ -609,21 +609,21 @@ def hst_spec(result_dict, plot=True, output_file ='hstspec.html', model = True):
     #plot planet spectrum
     mwave = result_dict['planet_spec']['model_wave']
     mspec = result_dict['planet_spec']['model_spec']
-    
+
     binwave = result_dict['planet_spec']['binwave']
     binspec = result_dict['planet_spec']['binspec']
-    
+
     error = result_dict['planet_spec']['error']
     error = np.zeros(len(binspec))+ error
     xlims = [result_dict['planet_spec']['wmin'], result_dict['planet_spec']['wmax']]
     ylims = [np.min(binspec)-2.0*error[0], np.max(binspec)+2.0*error[0]]
-    
+
     plot_spectrum = Figure(plot_width=800, plot_height=300, x_range=xlims,
                                y_range=ylims, tools=TOOLS,#responsive=True,
                                  x_axis_label='Wavelength [microns]',
-                                 y_axis_label='Ratio', 
+                                 y_axis_label='Ratio',
                                title="Original Model with Observation")
-    
+
     y_err = []
     x_err = []
     for px, py, yerr in zip(binwave, binspec, error):
@@ -633,8 +633,8 @@ def hst_spec(result_dict, plot=True, output_file ='hstspec.html', model = True):
         plot_spectrum.line(mwave,mspec, color= "black", alpha = 0.5, line_width = 4)
     plot_spectrum.circle(binwave,binspec, line_width=3, line_alpha=0.6)
     plot_spectrum.multi_line(x_err, y_err)
-    
-    if plot: 
+
+    if plot:
         outputfile(output_file)
         show(plot_spectrum)
 
@@ -642,19 +642,19 @@ def hst_spec(result_dict, plot=True, output_file ='hstspec.html', model = True):
 
 def hst_time(result_dict, plot=True, output_file ='hsttime.html', model = True):
     """Plot earliest and latest start times for hst observation
-    
+
     Parameters
     ----------
-    result_dict : dict 
+    result_dict : dict
         Dictionary from pandexo output.
-    
-    plot : bool 
+
+    plot : bool
         (Optional) True renders plot, False does not. Default=True
-    model : bool 
+    model : bool
         (Optional) Plot model under data. Default=True
     output_file : str
-        (Optional) Default = 'hsttime.html'    
-    
+        (Optional) Default = 'hsttime.html'
+
     Return
     ------
     obsphase1 : numpy array
@@ -673,17 +673,17 @@ def hst_time(result_dict, plot=True, output_file ='hsttime.html', model = True):
     hst_spec
     """
     TOOLS = "pan,wheel_zoom,box_zoom,resize,reset,save"
-    #earliest and latest start times 
+    #earliest and latest start times
     obsphase1 = result_dict['calc_start_window']['obsphase1']
     obstr1 = result_dict['calc_start_window']['obstr1']
     rms = result_dict['calc_start_window']['light_curve_rms']
     obsphase2 = result_dict['calc_start_window']['obsphase2']
     obstr2 = result_dict['calc_start_window']['obstr2']
-    phase1 = result_dict['calc_start_window']['phase1']    
+    phase1 = result_dict['calc_start_window']['phase1']
     phase2 = result_dict['calc_start_window']['phase2']
     trmodel1 = result_dict['calc_start_window']['trmodel1']
-    trmodel2 = result_dict['calc_start_window']['trmodel2']    
-    
+    trmodel2 = result_dict['calc_start_window']['trmodel2']
+
     if isinstance(rms, float):
         rms = np.zeros(len(obsphase1))+rms
     y_err1 = []
@@ -701,28 +701,28 @@ def hst_time(result_dict, plot=True, output_file ='hsttime.html', model = True):
     early = Figure(plot_width=400, plot_height=300,
                                tools=TOOLS,#responsive=True,
                                  x_axis_label='Orbital Phase',
-                                 y_axis_label='Flux', 
+                                 y_axis_label='Flux',
                                title="Earliest Start Time")
-    
+
     if model: early.line(phase1, trmodel1, color='black',alpha=0.5, line_width = 4)
     early.circle(obsphase1, obstr1, line_width=3, line_alpha=0.6)
     early.multi_line(x_err1, y_err1)
-     
-    late = Figure(plot_width=400, plot_height=300, 
+
+    late = Figure(plot_width=400, plot_height=300,
                                 tools=TOOLS,#responsive=True,
                                  x_axis_label='Orbital Phase',
-                                 y_axis_label='Flux', 
+                                 y_axis_label='Flux',
                                title="Latest Start Time")
     if model: late.line(phase2, trmodel2, color='black',alpha=0.5, line_width = 3)
     late.circle(obsphase2, obstr2, line_width=3, line_alpha=0.6)
     late.multi_line(x_err2, y_err2)
 
-    start_time = row(early, late)    
-    
-    if plot: 
+    start_time = row(early, late)
+
+    if plot:
         outputfile(output_file)
         show(start_time)
-    
 
-    
+
+
     return obsphase1, obstr1, obsphase2, obstr2,rms


### PR DESCRIPTION
Hey,
I think I found a bug in jpi.jwst_1d_spec().  When the input ``exo_dict['observation']['fraction']`` is not 1, jwst_1d_spec() returns bogus values for the resampled spectrum (``y``).  The problem seems to be that you need to scale the in-transit/out-of-transit rawData arrays by the integration time.   When I fix this, the resampled spectrum looks ok again.

best,
Patricio.

PS: the diff looks ugly because I removed the trailing blank characters, but the only part I really edited are lines 86-136 into this:

``` python
        if num_tran is False:
            num_tran = ntran_old

        if dict['input']['Primary/Secondary']=='fp/f*':
            fac = -1.0
        else:
            fac =  1.0

        fraction = (dict['timing']['Num Integrations In Transit'] /
                    dict['timing']['Num Integrations Out of Transit'])

        out  = dict['RawData']['electrons_out']* num_tran/ntran_old * fraction
        inn  = dict['RawData']['electrons_in'] * num_tran/ntran_old
        vout = dict['RawData']['var_out']      * num_tran/ntran_old * fraction
        vin  = dict['RawData']['var_in']       * num_tran/ntran_old

        if R is not False:
            new_wave = bin_wave_to_R(x, R)
            out  = uniform_tophat_sum(new_wave, x, out)
            inn  = uniform_tophat_sum(new_wave, x, inn)
            vout = uniform_tophat_sum(new_wave, x, vout)
            vin  = uniform_tophat_sum(new_wave, x, vin)
            x = new_wave

        rand_noise = np.sqrt((vin+vout))*(np.random.randn(len(x)))
        sim_spec   = fac*(out-inn + rand_noise)/out
        y   = sim_spec
        err = np.sqrt(vout+vin)/out
```