### PR TITLE
Fixed typo in total variance in jpi.jwst_1d_spec()

### DIFF
--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -94,7 +94,7 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
             inn = uniform_tophat_sum(new_wave,x, dict['RawData']['electrons_in']*num_tran/ntran_old)
             vout = uniform_tophat_sum(new_wave,x, dict['RawData']['var_out']*num_tran/ntran_old)
             vin = uniform_tophat_sum(new_wave,x, dict['RawData']['var_in']*num_tran/ntran_old)
-            var_tot = (to/ti/out)**2.0 * vout + (inn*to/ti/out**2.0)**2.0 * vout
+            var_tot = (to/ti/out)**2.0 * vin + (inn*to/ti/out**2.0)**2.0 * vout
             if dict['input']['Primary/Secondary']=='fp/f*':
                 fac = -1.0
             else:
@@ -110,7 +110,7 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
             inn = dict['RawData']['electrons_in']*num_tran/ntran_old
             vout = dict['RawData']['var_out']*num_tran/ntran_old
             vin = dict['RawData']['var_in']*num_tran/ntran_old
-            var_tot = (to/ti/out)**2.0 * vout + (inn*to/ti/out**2.0)**2.0 * vout
+            var_tot = (to/ti/out)**2.0 * vin + (inn*to/ti/out**2.0)**2.0 * vout
             if dict['input']['Primary/Secondary']=='fp/f*':
                 fac = -1.0
             else:
@@ -127,7 +127,7 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
             inn = uniform_tophat_sum(new_wave,x, dict['RawData']['electrons_in'])
             vout = uniform_tophat_sum(new_wave,x, dict['RawData']['var_out'])
             vin = uniform_tophat_sum(new_wave,x, dict['RawData']['var_in'])
-            var_tot = (to/ti/out)**2.0 * vout + (inn*to/ti/out**2.0)**2.0 * vout
+            var_tot = (to/ti/out)**2.0 * vin + (inn*to/ti/out**2.0)**2.0 * vout
             if dict['input']['Primary/Secondary']=='fp/f*':
                 fac = -1.0
             else:


### PR DESCRIPTION
Hi,
This time I think I got it right:
The error-propagation equation had the out-of-transit variance in place of the in-transit variance.

best,
p