### PR TITLE
always use static_url

### DIFF
--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -423,7 +423,7 @@ class CalculationNewHandler(BaseHandler):
         
         
         self.write(dict(response))
-        self.redirect("/dashboard")
+        self.redirect("../dashboard")
         
     
 class CalculationNewHSTHandler(BaseHandler):
@@ -514,7 +514,7 @@ class CalculationNewHSTHandler(BaseHandler):
         
         
         self.write(dict(response))
-        self.redirect("/dashboardhst")
+        self.redirect("../dashboardhst")
         
             
 class CalculationNewSpecHandler(BaseHandler):
@@ -613,7 +613,7 @@ class CalculationNewSpecHandler(BaseHandler):
         
         
         self.write(dict(response))
-        self.redirect("/dashboardspec")
+        self.redirect("../dashboardspec")
 
 
 class CalculationStatusHandler(BaseHandler):

--- a/pandexo/engine/templates/base.html
+++ b/pandexo/engine/templates/base.html
@@ -104,9 +104,9 @@
 <footer>
     <div class="container">
         <hr></hr>
-        <p class="text-muted">Space Telescope Science Institute</p>
-        <p><img src="https://zenodo.org/badge/doi/10.5281/zenodo.47866.svg" alt="10.5281/zenodo.47866">
-        <a href="http://dx.doi.org/10.5281/zenodo.47866"></a></p>
+        <!--<p class="text-muted">Space Telescope Science Institute</p>-->
+        <!--<p><img src="https://zenodo.org/badge/doi/10.5281/zenodo.47866.svg" alt="10.5281/zenodo.47866">-->
+        <!--<a href="http://dx.doi.org/10.5281/zenodo.47866"></a></p>-->
     </div>
 </footer>
 

--- a/pandexo/engine/templates/errors.html
+++ b/pandexo/engine/templates/errors.html
@@ -17,7 +17,7 @@
     </div>
 
     <div class="col-md-3">
-        <img style="width: 100%;"" src="../../static/img/giphy-1.gif">
+        <img style="width: 100%;" src="{{ static_url('img/giphy-1.gif') }}">
     </div>
 
     <div class="col-md-9">
@@ -29,7 +29,7 @@
     </div>
     
     <div class="col-md-3">
-        <img style="width: 100%;" src="../../static/img/giphy.gif" />
+        <img style="width: 100%;" src="{{ static_url('img/giphy.gif') }}" />
     </div>
 
     <div class="col-md-9">

--- a/pandexo/engine/templates/home.html
+++ b/pandexo/engine/templates/home.html
@@ -15,7 +15,7 @@
 <div class="row">
     <div class="col-md-6">
     <div class="thumbnail">
-      <img src="../static/img/jwst_thumb.jpg" alt="...">
+      <img src="{{ static_url('img/jwst_thumb.jpg') }}" alt="...">
       <div class="caption">
         <p><a href="/calculation/new" class="btn btn-success btn-lg" role="button">New Calculation</a> <a href="/dashboard" class="btn btn-default btn-lg" role="button">Dashboard</a></p>
       </div>
@@ -23,7 +23,7 @@
   </div>
     <div class="col-md-6">
     <div class="thumbnail">
-      <img src="../static/img/hst_thumb.jpg" alt="...">
+      <img src="{{ static_url('img/hst_thumb.jpg') }}" alt="...">
       <div class="caption">
         <p><a href="/calculation/newHST" class="btn btn-success btn-lg" role="button">New Calculation</a> <a href="/dashboardhst" class="btn btn-default btn-lg" role="button">Dashboard</a></p>
       </div>

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -210,7 +210,7 @@
             <h4>JWST Instrument Modes</h4>
         </div>
         <div class="col-md-6 col-md-offset-3">
-            <img id="full" alt="-" width="660" height="426" src="../static/img/pec_res.jpg" style="left: -63px;position: relative;">
+            <img id="full" alt="-" width="660" height="426" src="{{ static_url('img/pec_res.jpg') }}" style="left: -63px;position: relative;">
         </div>
     </div>
 


### PR DESCRIPTION
This makes links more predictable for text replacement when running under a non-root location on a server.