### PR TITLE
expand command line functionality

### DIFF
--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -24,6 +24,7 @@ __TEMP__ = os.environ.get("PANDEXO_TEMP", os.path.join(os.path.dirname(__file__)
 
 define("port", default=1111, help="run on the given port", type=int)
 define("debug", default=False, help="automatically detect code changes in development")
+define("workers", default=4, help="maximum number of simultaneous async tasks")
 #define("log_file_prefix", default=__LOG__ + "pandexo_logs.log", help="where to store logs")
 
 # Define a simple named tuple to keep track for submitted calculations
@@ -74,7 +75,7 @@ class BaseHandler(tornado.web.RequestHandler):
     """
     Logic to handle user information and database access might go here.
     """
-    executor = ProcessPoolExecutor(max_workers=4)
+    executor = ProcessPoolExecutor(max_workers=options.workers)
     buffer = OrderedDict()
 
     def _get_task_response(self, id):

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,9 @@ setup(
           'batman-package',
           'photutils',
           'astropy'
-          ]
+          ],
+    entry_points = {
+        'console_scripts':
+            ['start_pandexo=pandexo.engine.run_online:main']
+    }
 )


### PR DESCRIPTION
This PR adds an `entry_point` to start the web GUI from the command-line via `start_pandexo` and `workers` as a command line option to set the number of task run in parallel.