### PR TITLE
fix status update issue

### DIFF
--- a/pandexo/engine/static/js/starter.home.js
+++ b/pandexo/engine/static/js/starter.home.js
@@ -17,6 +17,15 @@ function updateStatus(statusUrl) {
     // Query the status url for information about the state of the calculation
     $.getJSON(statusUrl, function(response) {
         $('#m' + response.id).replaceWith(response.html);
+
+        // hack to make sure links are properly replaced in non-root locations
+        var calc_prefix = "/calculation/"
+        $("a[href^='/calculation/']")
+            .each(function()
+            {
+                 this.href = this.href.replace(/\/calculation\//,
+                 calc_prefix);
+            });
         if ((response.state != 'finished') && (response.state != 'cancelled')) {
             // Check in another 2 seconds
             setTimeout(function() {


### PR DESCRIPTION
This will make sure the link the HTML table row returned in the status gives the correct link to the result page when running in a non-root location.