### PR TITLE
Added Astropy-3 Hack to Troubleshooting in Docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -170,6 +170,26 @@ CONDA USERS:
     conda install sphinx=1.5.6
     
 
+Using Astropy-3 instead of Astropy-2
+````````````````````````````````````
+
+To allow PandExo to use Astropy-3 instead of Astropy-2, which is required by Pandeia, follow these instructions:
+
+After installing `pandeia.engine`, edit the file
+
+$HOME/anaconda3/lib/python3.6/site-packages/pandeia/engine/sed.py
+
+On `line 8`, comment out
+
+`from astropy.analytic_functions import blackbody_nu`
+
+and add
+
+`from astropy.modeling.blackbody import blackbody_nu`
+
+Pandeia requires Astropy-2; but this fix will let PandExo use `pandeia.engine` with Astropy-3
+
+
 The Importance of Upgrading PandExo
 ===================================
 
@@ -192,6 +212,3 @@ Verify pandexo.engine is Current
 .. code-block:: bash 
 
     pip install pandexo.engine --upgrade 
-
-
-


### PR DESCRIPTION
During the installation process, PandExo suggests Astropy-2, instead of Astropy-3. This is because Pandeia on the backend requires Astropy==2.0.2.

When it comes to using PandExo with Pandeia, the sub-package that requires Astropy-2 is `astropy.analytic_functions` -- because Pandeia uses import `astropy.analytic_functions.blacbody_nu`. Astropy-3 now places the blackbody_nu inside astro.modeling.blackbody, instead of `astropy.analytic_functions`.

If Pandeia were to edit the file sed.py in $HOME/anaconda3/lib/python3.6/site-packages/pandeia/engine/sed.py and change the import on line 8, from

`from astropy.analytic_functions import blackbody_nu`

to

`from astropy.modeling.blackbody import blackbody_nu`

Then PandExo (and maybe Pandeia) could use Astropy-3, which is now default for the community.

It might be useful to add a suggestion during the install, or in the documentation, for moderate-to-advanced users to edit this one line in Pandeia, in order to update Pandeia and PandExo to Astropy-3.

I added this comment to the trouble shooting page of the `installation.rst` file in PandExo/docs

```
open $HOME/anaconda3/lib/python3.6/site-packages/pandeia/engine/sed.py
```

On `line 8`, comment out

`from astropy.analytic_functions import blackbody_nu`

and add

`from astropy.modeling.blackbody import blackbody_nu`

