### PR TITLE
Explain the errors in the HST time series plot

### DIFF
--- a/docs/tutorialhst.rst
+++ b/docs/tutorialhst.rst
@@ -107,6 +107,7 @@ Plot simulated spectrum using specified file
 
 Compute earliest and latest start times for given start window size
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The errors in the time series are the error per wavelength channel.
 
 .. code:: python
 


### PR DESCRIPTION
It would be helpful to explain whether these are the errors per channel or the full broadband integrated light curve. I believe these are per channel so please check me on that before merging.