### PR TITLE
Enable passing the stellar or planetary spectra as dict objects

### DIFF
--- a/pandexo/engine/create_input.py
+++ b/pandexo/engine/create_input.py
@@ -34,7 +34,11 @@ def outTrans(input) :
 
     ################# USER ####################################
     if input['type'] == 'user':
-        star = np.genfromtxt(input['starpath'], dtype=(float, float), names='w, f') #pyfits.getdata(input['starpath'],1)
+        if isinstance(input['starpath'], dict):
+            star = input['starpath']
+        else: #if isinstance(input['starpath'], str):
+            star = np.genfromtxt(input['starpath'], dtype=(float, float),
+                                 names='w, f')
         #get flux 
         flux = star['f'] #star.field(input['logg'])
         #get wavelength and reference wavelength for mag normalization
@@ -153,7 +157,11 @@ def bothTrans(out_trans, planet,star=None) :
     """ 
     
     if planet['type'] =='user':
-        load_file = np.genfromtxt(planet['exopath'], dtype=(float, float), names='w, f')   
+        if isinstance(planet['exopath'], dict):
+            load_file = planet['exopath']
+        else: #if isinstance(planet['exopath'], str):
+            load_file = np.genfromtxt(planet['exopath'], dtype=(float, float),
+                names='w, f')
         #get wavelength 
         wave_planet = load_file['w']
         #get planet flux 


### PR DESCRIPTION
Previous behavior (passing spectra as files) is preserved.

Here below I'm also appending respective tests (I'm not sure where to put them as the repo doesn't seem to have a unit/integration test suite).

There should be also need for documentation, as the user would need to know how to define the dictionaries. But you can pick that up from the tests.

Closes #35 

And the tests:
```python
import os
import pytest

import numpy as np
import scipy.constants as sc

import pandexo.engine.justdoit as jdi


expected_error_stellar = np.array([
    2.13840185e-05, 1.97318534e-05, 1.88798040e-05, 1.88264026e-05,
    1.82046902e-05, 1.81607942e-05, 1.75763805e-05, 1.70678170e-05,
    1.71121600e-05, 1.70282817e-05, 1.66428788e-05, 1.62861846e-05,
    1.62529514e-05, 1.61814838e-05, 1.58671556e-05, 1.54586962e-05,
    1.55947762e-05, 1.54131831e-05, 1.51584330e-05, 1.50462866e-05,
    1.50928701e-05, 1.50778715e-05, 1.50336681e-05, 1.50676745e-05,
    1.49915050e-05, 1.50325074e-05, 1.52789566e-05, 1.54689081e-05,
    1.71048232e-05, 2.28916352e-05, 1.59629608e-05, 1.63793970e-05,
    1.64288715e-05, 1.63493139e-05, 1.67706493e-05, 1.69020379e-05,
    1.73091719e-05, 1.74863452e-05, 1.75649348e-05, 1.77469600e-05,
    1.78962272e-05, 1.80444946e-05, 1.86704238e-05, 1.88811379e-05,
    1.92962511e-05, 1.94767445e-05, 1.94299493e-05, 1.97970762e-05,
    1.98783183e-05, 2.04394899e-05, 2.08916753e-05, 2.11416863e-05,
    2.15672112e-05, 2.16623977e-05, 2.20528957e-05, 2.22590479e-05,
    2.28406556e-05, 2.19265759e-05, 3.00168169e-05])

expected_planet_spectrum = np.array([
    1.04091632, 1.01934678, 0.99825059, 0.97802209, 0.95854147,
    0.94004325, 0.92223228, 0.90510846, 0.88884477, 0.87277661,
    0.85802043, 0.84341072, 0.82937353, 0.81616514, 0.80344718,
    0.79077183, 0.77923117, 0.76776823, 0.75675711, 0.74638783,
    0.73631924, 0.72686662, 0.7176268 , 0.70882563, 0.70032537,
    0.69217572, 0.68434318, 0.6769162 , 0.67036788, 0.64844385,
    0.64382514, 0.63792345, 0.63243262, 0.62699779, 0.62182221,
    0.61693967, 0.61212611, 0.60756971, 0.60319737, 0.59899801,
    0.59499812, 0.5911302 , 0.58735181, 0.58382793, 0.58044184,
    0.57714169, 0.57402253, 0.57102793, 0.56810494, 0.5653973 ,
    0.56273696, 0.5601829 , 0.55773016, 0.55541027, 0.55310259,
    0.55095318, 0.54886269, 0.54677189, 0.54508002])

@pytest.mark.parametrize('as_dict', [True, False])
def test_stellar_spectrum_user(as_dict):
    wl = np.linspace(0.8, 2.0, 2000)
    nu = sc.c/(wl*1e-6)  # frequency in sec^-1
    teff = 5500.0
    planck_5500K = nu**3 / (np.exp(sc.h*nu/sc.k/teff) - 1)

    if as_dict:
        starflux = {'f':planck_5500K, 'w':wl}
    else:
        starflux = 'planck_5500K.dat'
        with open(starflux, 'w') as sf:
            for w,f in zip(wl, planck_5500K):
                sf.write(f'{w:.15f}   {f:.15e}\n')

    exo_dict = jdi.load_exo_dict()
    exo_dict['observation']['sat_level'] = 80
    exo_dict['observation']['sat_unit'] = '%'
    exo_dict['observation']['noccultations'] = 2
    exo_dict['observation']['R'] = 49
    exo_dict['observation']['baseline'] = 1.0
    exo_dict['observation']['baseline_unit'] = 'frac'
    exo_dict['observation']['noise_floor'] = 0

    exo_dict['star']['type'] = 'user'
    exo_dict['star']['starpath'] = starflux
    exo_dict['star']['w_unit'] = 'um'
    exo_dict['star']['f_unit'] = 'erg/cm2/s/Hz'
    exo_dict['star']['mag'] = 8.0
    exo_dict['star']['ref_wave'] = 1.25
    exo_dict['star']['radius'] = 1
    exo_dict['star']['r_unit'] = 'R_sun'
    exo_dict['planet']['type'] = 'constant'
    exo_dict['planet']['radius'] = 1
    exo_dict['planet']['r_unit'] = 'R_jup'
    exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0
    exo_dict['planet']['td_unit'] = 's'
    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'

    pandexo_sim = jdi.run_pandexo(exo_dict, ['NIRSpec G140H'], save_file=False)
    np.testing.assert_allclose(
        pandexo_sim['FinalSpectrum']['error_w_floor'],
        expected_error_stellar,
        rtol=1e-7)
    # Teardown:
    if not as_dict:
        os.remove(starflux)

@pytest.mark.parametrize('as_dict', [True, False])
def test_planetary_spectrum_user(as_dict):
    wl = np.linspace(0.8, 2.0, 2000)
    rayleigh_ish_spec = 0.5 + 0.5*wl**-4

    if as_dict:
        planet_spec = {'f':rayleigh_ish_spec, 'w':wl}
    else:
        planet_spec = 'planet_spec.dat'
        with open(planet_spec, 'w') as sf:
            for w,f in zip(wl, rayleigh_ish_spec):
                sf.write(f'{w:.15f}   {f:.15e}\n')

    exo_dict = jdi.load_exo_dict()
    exo_dict['observation']['sat_level'] = 80
    exo_dict['observation']['sat_unit'] = '%'
    exo_dict['observation']['noccultations'] = 2
    exo_dict['observation']['R'] = 49
    exo_dict['observation']['baseline'] = 1.0
    exo_dict['observation']['baseline_unit'] = 'frac'
    exo_dict['observation']['noise_floor'] = 10
    exo_dict['star']['type'] = 'phoenix'
    exo_dict['star']['temp'] = 5500
    exo_dict['star']['metal'] = 0.0
    exo_dict['star']['logg'] = 4.0
    exo_dict['star']['mag'] = 8.0
    exo_dict['star']['ref_wave'] = 1.25
    exo_dict['star']['radius'] = 1
    exo_dict['star']['r_unit'] = 'R_sun'

    exo_dict['planet']['type'] = 'user'
    exo_dict['planet']['exopath'] = planet_spec
    exo_dict['planet']['w_unit'] = 'um'
    exo_dict['planet']['radius'] = 1
    exo_dict['planet']['r_unit'] = 'R_jup'
    exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0
    exo_dict['planet']['td_unit'] = 's'
    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'

    pandexo_sim = jdi.run_pandexo(exo_dict, ['NIRSpec G140H'], save_file=False)
    np.testing.assert_allclose(
        pandexo_sim['FinalSpectrum']['spectrum'],
        expected_planet_spectrum,
        rtol=1e-7)
    # Teardown:
    if not as_dict:
        os.remove(planet_spec)
```