### PR TITLE
Fixed PandExo broken links on home, updated JDocs.

### DIFF
--- a/pandexo/engine/templates/base.html
+++ b/pandexo/engine/templates/base.html
@@ -104,7 +104,8 @@
 <footer>
     <div class="container">
         <hr></hr>
-        <p style="float:right;"><a href="https://doi.org/10.5281/zenodo.2012696"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.2012696.svg" alt="DOI"></a></p> 
+        <p style="float:right;"><a href="https://doi.org/10.5281/zenodo.3997978"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3997978.svg" alt="DOI"></a>
+</p> 
     </div>
 </footer>
 

--- a/pandexo/engine/templates/home.html
+++ b/pandexo/engine/templates/home.html
@@ -47,8 +47,7 @@
         
         <h2>Important Links</h2>
         <ul>
-                 <li><a href="https://jwst-docs.stsci.edu/display/JPP/Step-by-Step+PandExo+Guide+for+NIRISS+SOSS+Science+Use+Case">Step-by-Step PandExo Guide for NIRISS SOSS Science Use Case</a></li>
-         <li><a href="https://jwst-docs.stsci.edu/display/JPP/Step-by-Step+PandExo+Guide+for+NIRCam+Grism+Time+Series+Science+Use+Case">Step-by-Step PandExo Guide for NIRCam Grism Time Series Science Use Case</a></li>  
+        <li><a href="https://jwst-docs.stsci.edu/jwst-other-tools/exoplanet-observations-proposal-tools/pandexo-the-exoplanet-etc">PandExo online JWST documentation</a></li>
         <li><a href="https://github.com/natashabatalha/PandExo">PandExo Github</a></li>
         <li><a href="https://natashabatalha.github.io/PandExo/installation.html">Guide to Installing PandExo</a></li>
         <li><a href="https://natashabatalha.github.io/PandExo/tutorialjwst.html#editting-input-dictionaries">Editting Input Dict Manually</a></li>


### PR DESCRIPTION
Hey @natashabatalha,

 Turns out we missed replacing some links in the PandExo home page of some previously written step-by-step guides which are no longer in JDox, with the actual new JDox article on PandExo. This fixes that, so now all should be up-to-date.

 Change is simple enough that merging should be easy; once you do that, I can update the PandExo STScI's webpage.

 Thanks!
Néstor