### PR TITLE
Fix dependency issue with astropy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
           'pandeia.engine==1.5.1',
           'batman-package',
           'photutils',
-          'astropy',
+          'astropy==4.2',
           'pysynphot',
           'sqlalchemy',
           'astroquery',


### PR DESCRIPTION
Simply installing the `pandexo.engine` package via pip and running the `run_test.py` script results in the following error:

```
[...]
File "[...]/lib/python3.7/site-packages/pandeia/engine/sed.py", line 8, in <module>
from astropy.modeling.blackbody import blackbody_nu
ModuleNotFoundError: No module named 'astropy.modeling.blackbody'
```

This error is caused by a renaming of `astropy.modeling.blackbody` to `astropy.modeling.BlackBody` from version 4.2 to 4.3 of astropy. Since the error occurs in the pandeia module whose version is already fixed, the most reasonable solution is to fix the version of astropy as well.