### PR TITLE
Remove aperture blocking factor

### DIFF
--- a/pandexo/engine/justdoit.py
+++ b/pandexo/engine/justdoit.py
@@ -237,8 +237,6 @@ def get_thruput(inst, niriss=1, nirspec='f100lp', wmin='default', wmax='default'
     conf['detector']['ngroup'] = 2
 
     if conf['instrument']['instrument'].lower() =='niriss':
-        #pandeia handles slit losses inside the 2d engine. So, you need to account for the
-        #extra .663 here
         conf["instrument"]["disperser"] = conf["instrument"]["disperser"] +'_'+str(niriss)
         i = InstrumentFactory(config=conf)
         wr = i.get_wave_range()
@@ -248,7 +246,7 @@ def get_thruput(inst, niriss=1, nirspec='f100lp', wmin='default', wmax='default'
             wmax = wr['wmax']
         wave = np.linspace(wmin, wmax, num=500)
         pce = i.get_total_eff(wave)
-        return {'wave':wave,'pce':0.663*pce}
+        return {'wave':wave,'pce':pce}
     elif (conf['instrument']['instrument'].lower() =='nirspec') and ('g140' in conf["instrument"]["disperser"]):
         conf["instrument"]["filter"] = nirspec
 


### PR DESCRIPTION
Aperture blocking factor of 0.663 is accounted for by WebbPSF, and therefore does not need to be accounted for again here.

See plot below of NIRISS PCEs produced by STScI, and those produced by PandExo

![image001](https://github.com/natashabatalha/PandExo/assets/23636747/bf7bd72c-acbb-45d0-b3a3-caa705e3d8e2)
![PastedGraphic-2](https://github.com/natashabatalha/PandExo/assets/23636747/0d892ae0-1621-4abe-876d-8a48cb6ca6c6)