### PR TITLE
Fix JWST wavelength ordering and update PandExo tutorial tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,73 @@
-*.pyc
-*.html~
-*.p
-*.json~
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.python-version
 
-# Jupyter Notebooks
-.ipynb_checkpoints
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+conda-env/
+
+# Local environment and secrets
+.env
+.env.*
+!.env.example
+!.env.sample
+
+# Editors and IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Jupyter notebooks
+.ipynb_checkpoints/
 notebooks/*.html
 
-# Installation
+# Test and coverage output
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+.pytest_cache/
+.tox/
+.nox/
+
+# Type checking and lint caches
+.mypy_cache/
+.ruff_cache/
+.pyre/
+
+# Build and packaging output
 build/
 dist/
 *.egg-info/
+*.egg
+pip-wheel-metadata/
 
-# Mac files
-*.DS_Store
+# Generated PandExo/output artifacts
+*.p
+*.pkl
+*.pickle
+*.fits
+*.h5
+*.hdf5
 
+# Logs and temporary files
+*.log
+*.tmp
+*.bak
+*.orig
+*.html~
+*.json~
 
-# test files
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test files
 tests/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+PYTHON        = python
 PAPER         =
 BUILDDIR      = ../../pandexo-docs
 PDFBUILDDIR   = /tmp
@@ -21,10 +22,12 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: help clean tutorials check-tutorials html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  tutorials  to regenerate RST tutorials from notebooks"
+	@echo "  check-tutorials to verify generated tutorial RST is up to date"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
@@ -51,7 +54,13 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 
-html:
+tutorials:
+	$(PYTHON) generate_tutorial_rst.py
+
+check-tutorials:
+	$(PYTHON) generate_tutorial_rst.py --check
+
+html: tutorials
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/generate_tutorial_rst.py
+++ b/docs/generate_tutorial_rst.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""Generate RST tutorial pages from their notebook sources."""
+
+from __future__ import print_function
+
+import argparse
+import difflib
+import os
+import sys
+
+import nbformat
+from nbconvert import RSTExporter
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+TUTORIALS = {
+    os.path.join("notebooks", "JWST_Running_Pandexo.ipynb"): {
+        "output": os.path.join("docs", "tutorialjwst.rst"),
+        "title": "JWST Tutorial",
+    },
+}
+
+
+def _strip_generated_toc(notebook):
+    """Remove the notebook-only Table of Contents cell before conversion."""
+    cells = list(notebook.cells)
+    if cells and cells[0].cell_type == "markdown":
+        source = cells[0].source
+        if "Table of Contents" in source and "tocSkip" in source:
+            notebook.cells = cells[1:]
+    return notebook
+
+
+def _demote_rst_headings(body):
+    """Demote notebook headings so the docs page can add its own title."""
+    demote = {
+        "=": "-",
+        "-": "~",
+        "~": "^",
+        "^": '"',
+    }
+    lines = body.splitlines()
+    for index, line in enumerate(lines[1:], start=1):
+        stripped = line.strip()
+        if stripped and len(set(stripped)) == 1 and stripped[0] in demote:
+            if len(stripped) >= len(lines[index - 1].strip()):
+                lines[index] = demote[stripped[0]] * len(line)
+    return "\n".join(lines) + ("\n" if body.endswith("\n") else "")
+
+
+def _strip_trailing_whitespace(body):
+    return "\n".join(line.rstrip() for line in body.splitlines()) + "\n"
+
+
+def _render_notebook(notebook_path, title):
+    notebook = nbformat.read(notebook_path, as_version=4)
+    notebook = _strip_generated_toc(notebook)
+
+    body, _resources = RSTExporter().from_notebook_node(notebook)
+    body = _strip_trailing_whitespace(_demote_rst_headings(body.lstrip()))
+
+    header = [
+        ".. AUTO-GENERATED FILE. DO NOT EDIT.",
+        ".. Generated from {} by docs/generate_tutorial_rst.py.".format(
+            os.path.relpath(notebook_path, ROOT)
+        ),
+        "",
+        title,
+        "=" * len(title),
+        "",
+        "",
+    ]
+    return "\n".join(header) + body
+
+
+def _write_or_check(notebook_relpath, config, check=False):
+    notebook_path = os.path.join(ROOT, notebook_relpath)
+    output_path = os.path.join(ROOT, config["output"])
+    rendered = _render_notebook(notebook_path, config["title"])
+
+    if check:
+        try:
+            with open(output_path, "r") as handle:
+                current = handle.read()
+        except IOError:
+            current = ""
+
+        if current != rendered:
+            diff = difflib.unified_diff(
+                current.splitlines(True),
+                rendered.splitlines(True),
+                fromfile=config["output"],
+                tofile="generated {}".format(config["output"]),
+            )
+            sys.stdout.writelines(diff)
+            return False
+        return True
+
+    with open(output_path, "w") as handle:
+        handle.write(rendered)
+    print("Generated {}".format(config["output"]))
+    return True
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if generated RST differs from the checked-in files",
+    )
+    args = parser.parse_args(argv)
+
+    ok = True
+    for notebook_relpath, config in TUTORIALS.items():
+        ok = _write_or_check(notebook_relpath, config, check=args.check) and ok
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/tutorialjwst.rst
+++ b/docs/tutorialjwst.rst
@@ -1,25 +1,45 @@
+.. AUTO-GENERATED FILE. DO NOT EDIT.
+.. Generated from notebooks/JWST_Running_Pandexo.ipynb by docs/generate_tutorial_rst.py.
+
 JWST Tutorial
 =============
 
+Getting Started
+---------------
+
+Before starting here, all the instructions on the `installation
+page <https://natashabatalha.github.io/PandExo/installation.html>`__
+should be completed!
+
 Here you will learn how to:
 
--  set planet properties
--  set stellar properties
--  run default instrument modes
--  adjust instrument modes
--  run pandexo
+- set planet properties
+- set stellar properties
+- run default instrument modes
+- adjust instrument modes
+- run pandexo
 
 .. code:: ipython3
 
     import warnings
     warnings.filterwarnings('ignore')
     import pandexo.engine.justdoit as jdi # THIS IS THE HOLY GRAIL OF PANDEXO
+    import pandexo.engine.justplotit as jpi
     import numpy as np
     import os
     #pip install pandexo.engine --upgrade
 
-Setting up a run
-----------------
+Make sure that your environment path is set to match the correct version
+of pandeia
+
+.. code:: ipython3
+
+    print(os.environ['pandeia_refdata'] )
+    import pandeia.engine
+    print(pandeia.engine.__version__)
+
+Load blank exo dictionary
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To start, load in a blank exoplanet dictionary with empty keys. You will
 fill these out for yourself in the next step.
@@ -31,83 +51,120 @@ fill these out for yourself in the next step.
     #print(exo_dict['star']['w_unit'])
 
 Edit exoplanet observation inputs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Editting each keys are annoying. But, do this carefully or it could
 result in nonsense runs
 
 .. code:: ipython3
 
-    exo_dict['observation']['sat_level'] = 80    #saturation level in percent of full well 
+    exo_dict['observation']['sat_level'] = 80    #saturation level in percent of full well
     exo_dict['observation']['sat_unit'] = '%'
-    exo_dict['observation']['noccultations'] = 2 #number of transits 
-    exo_dict['observation']['R'] = None          #fixed binning. I usually suggest ZERO binning.. you can always bin later 
+    exo_dict['observation']['noccultations'] = 1 #number of transits
+    exo_dict['observation']['R'] = None          #fixed binning. I usually suggest ZERO binning.. you can always bin later
                                                  #without having to redo the calcualtion
     exo_dict['observation']['baseline_unit'] = 'total'  #Defines how you specify out of transit observing time
-                                                        #'frac' : fraction of time in transit versus out = in/out 
+                                                        #'frac' : fraction of time in transit versus out = in/out
                                                         #'total' : total observing time (seconds)
     exo_dict['observation']['baseline'] = 4.0*60.0*60.0 #in accordance with what was specified above (total observing time)
-    
-    exo_dict['observation']['noise_floor'] = 0   #this can be a fixed level or it can be a filepath 
+
+    exo_dict['observation']['noise_floor'] = 0   #this can be a fixed level or it can be a filepath
                                                  #to a wavelength dependent noise floor solution (units are ppm)
 
 Edit exoplanet host star inputs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Note… If you select ‘phoenix’ you **do not** have to provide a starpath,
-w_unit or f_unit, but you **do** have to provide a temp, metal and logg.
-If you select ‘user’ you **do not** need to provide a temp, metal and
-logg, but you **do** need to provide units and starpath.
+Note… If you select ``phoenix`` you **do not** have to provide a
+``starpath``, ``w_unit`` or ``f_unit``, but you **do** have to provide a
+``temp``, ``metal`` and ``logg``. If you select ``user`` you **do not**
+need to provide a ``temp``, ``metal`` and ``logg``, but you **do** need
+to provide units and starpath.
+
+Option 1) Grab stellar model from database
+""""""""""""""""""""""""""""""""""""""""""
 
 .. code:: ipython3
 
+    #OPTION 1 get start from database
     exo_dict['star']['type'] = 'phoenix'        #phoenix or user (if you have your own)
-    exo_dict['star']['mag'] = 8.0               #magnitude of the system
+    exo_dict['star']['mag'] = 10.0              #magnitude of the system
     exo_dict['star']['ref_wave'] = 1.25         #For J mag = 1.25, H = 1.6, K =2.22.. etc (all in micron)
-    exo_dict['star']['temp'] = 5500             #in K 
+    exo_dict['star']['temp'] = 5500             #in K
     exo_dict['star']['metal'] = 0.0             # as log Fe/H
     exo_dict['star']['logg'] = 4.0              #log surface gravity cgs
 
+Option 2) Input as dictionary or filename
+"""""""""""""""""""""""""""""""""""""""""
+
+.. code:: ipython3
+
+    #Let's create a little fake stellar input
+
+    import scipy.constants as sc
+    wl = np.linspace(0.5, 15, 3000)
+    nu = sc.c/(wl*1e-6)  # frequency in sec^-1
+    teff = 5500.0
+    planck_5500K = nu**3 / (np.exp(sc.h*nu/sc.k/teff) - 1)
+
+    #can either be dictionary input
+    starflux = {'f':planck_5500K, 'w':wl}
+    #or can be as a stellar file
+    #starflux = 'planck_5500K.dat'
+    #with open(starflux, 'w') as sf:
+    #    for w,f in zip(wl, planck_5500K):
+    #        sf.write(f'{w:.15f}   {f:.15e}\n')
+
+    exo_dict['star']['type'] = 'user'
+    exo_dict['star']['mag'] = 10.0              #magnitude of the system
+    exo_dict['star']['ref_wave'] = 1.25
+    exo_dict['star']['starpath'] = starflux
+    exo_dict['star']['w_unit'] = 'um'
+    exo_dict['star']['f_unit'] = 'erg/cm2/s/Hz'
+
 Edit exoplanet inputs using one of three options
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1) user specified
 2) constant value
 3) select from grid
 
 1) Edit exoplanet planet inputs if using your own model
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 .. code:: ipython3
 
     exo_dict['planet']['type'] ='user'                       #tells pandexo you are uploading your own spectrum
     exo_dict['planet']['exopath'] = 'wasp12b.txt'
+
+    #or as a dictionary
+    #exo_dict['planet']['exopath'] = {'f':spectrum, 'w':wavelength}
+
     exo_dict['planet']['w_unit'] = 'cm'                      #other options include "um","nm" ,"Angs", "sec" (for phase curves)
-    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'               #other options are 'fp/f*' 
-    exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration 
+    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'               #other options are 'fp/f*'
+    exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration
     exo_dict['planet']['td_unit'] = 's'                      #Any unit of time in accordance with astropy.units can be added
 
 2) Users can also add in a constant temperature or a constant transit depth
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 .. code:: ipython3
 
     exo_dict['planet']['type'] = 'constant'                  #tells pandexo you want a fixed transit depth
-    exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration 
-    exo_dict['planet']['td_unit'] = 's' 
+    exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration
+    exo_dict['planet']['td_unit'] = 's'
     exo_dict['planet']['radius'] = 1
     exo_dict['planet']['r_unit'] = 'R_jup'            #Any unit of distance in accordance with astropy.units can be added here
     exo_dict['star']['radius'] = 1
     exo_dict['star']['r_unit'] = 'R_sun'              #Same deal with astropy.units here
-    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'        #this is what you would do for primary transit 
-    
+    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'        #this is what you would do for primary transit
+
     #ORRRRR....
-    #if you wanted to instead to secondary transit at constant temperature 
-    exo_dict['planet']['f_unit'] = 'fp/f*' 
-    exo_dict['planet']['temp'] = 1000
+    #if you wanted to instead to secondary transit at constant temperature
+    #exo_dict['planet']['f_unit'] = 'fp/f*'
+    #exo_dict['planet']['temp'] = 1000
 
 3) Select from grid
-^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""
 
 NOTE: Currently only the fortney grid for hot Jupiters from Fortney+2010
 is supported. Holler though, if you want another grid supported
@@ -115,9 +172,11 @@ is supported. Holler though, if you want another grid supported
 .. code:: ipython3
 
     exo_dict['planet']['type'] = 'grid'                #tells pandexo you want to pull from the grid
+    exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0
+    exo_dict['planet']['td_unit'] = 's'
     exo_dict['planet']['temp'] = 1000                 #grid: 500, 750, 1000, 1250, 1500, 1750, 2000, 2250, 2500
     exo_dict['planet']['chem'] = 'noTiO'              #options: 'noTiO' and 'eqchem', noTiO is chemical eq. without TiO
-    exo_dict['planet']['cloud'] = 'ray10'               #options: nothing: '0', 
+    exo_dict['planet']['cloud'] = 'ray10'               #options: nothing: '0',
     #                                                   Weak, medium, strong scattering: ray10,ray100, ray1000
     #                                                   Weak, medium, strong cloud: flat1,flat10, flat100
     exo_dict['planet']['mass'] = 1
@@ -126,11 +185,10 @@ is supported. Holler though, if you want another grid supported
     exo_dict['planet']['r_unit'] = 'R_jup'            #Any unit of distance in accordance with astropy.units can be added here
     exo_dict['star']['radius'] = 1
     exo_dict['star']['r_unit'] = 'R_sun'              #Same deal with astropy.units here
-    exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration 
-    exo_dict['planet']['td_unit'] = 's' 
+
 
 Load in instrument dictionary (OPTIONAL)
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Step 2 is optional because PandExo has the functionality to
 automatically load in instrument dictionaries. Skip this if you plan on
@@ -142,62 +200,61 @@ NIRSpec G140H - MIRI LRS - NIRISS SOSS
 
 .. code:: ipython3
 
-    #jdi.print_instruments()
-    result = jdi.run_pandexo(exo_dict,['NIRCam F322W2'])
+    jdi.print_instruments()
 
 .. code:: ipython3
 
     inst_dict = jdi.load_mode_dict('NIRSpec G140H')
-    
-    #loading in instrument dictionaries allow you to personalize some of  
-    #the fields that are predefined in the templates. The templates have 
-    #the subbarays with the lowest frame times and the readmodes with 1 frame per group. 
+
+    #loading in instrument dictionaries allow you to personalize some of
+    #the fields that are predefined in the templates. The templates have
+    #the subbarays with the lowest frame times and the readmodes with 1 frame per group.
     #if that is not what you want. change these fields
-    
-    #Try printing this out to get a feel for how it is structured: 
-    
+
+    #Try printing this out to get a feel for how it is structured:
+
     print(inst_dict['configuration'])
 
 .. code:: ipython3
 
-    #Another way to display this is to print out the keys 
+    #Another way to display this is to print out the keys
     inst_dict.keys()
 
 Don’t know what instrument options there are?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: ipython3
 
     print("SUBARRAYS")
     print(jdi.subarrays('nirspec'))
-    
+
     print("FILTERS")
     print(jdi.filters('nircam'))
-    
+
     print("DISPERSERS")
     print(jdi.dispersers('nirspec'))
 
 .. code:: ipython3
 
     #you can try personalizing some of these fields
-    
-    inst_dict["configuration"]["detector"]["ngroup"] = 'optimize'   #running "optimize" will select the maximum 
-                                                                    #possible groups before saturation. 
+
+    inst_dict["configuration"]["detector"]["ngroup"] = 'optimize'   #running "optimize" will select the maximum
+                                                                    #possible groups before saturation.
                                                                     #You can also write in any integer between 2-65536
-    
+
     inst_dict["configuration"]["detector"]["subarray"] = 'substrip256'   #change the subbaray
-    
+
 
 
 Adjusting the Background Level
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You may want to think about adjusting the background level of your
 observation, based on the position of your target. PandExo two options
 and three levels for the position:
 
--  ``ecliptic`` or ``minzodi``
--  ``low``, ``medium``, ``high``
+- ``ecliptic`` or ``minzodi``
+- ``low``, ``medium``, ``high``
 
 .. code:: ipython3
 
@@ -205,7 +262,7 @@ and three levels for the position:
     inst_dict['background_level'] = 'high'
 
 Running NIRISS SOSS Order 2
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 PandExo only will extract a single order at a time. By default, it is
 set to extract Order 1. Below you can see how to extract the second
@@ -226,18 +283,18 @@ order 2 calculation.
     inst_dict["configuration"]["detector"]["ngroup"] = ngroup_from_order1_run
 
 Running PandExo
----------------
+~~~~~~~~~~~~~~~
 
 You have **four options** for running PandExo. All of them are accessed
 through attribute **jdi.run_pandexo**. See examples below.
 
-``jdi.run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,                             output_path=os.getcwd(), output_file = '')``
+``jdi.run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,                             output_path=os.getcwd(), output_file = '', verbose=True)``
 
 Option 1- Run single instrument mode, single planet
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you forget which instruments are available run
-**jdi.print_isntruments()** and pick one
+**jdi.print_instruments()** and pick one
 
 .. code:: ipython3
 
@@ -245,10 +302,32 @@ If you forget which instruments are available run
 
 .. code:: ipython3
 
-    result = jdi.run_pandexo(exo_dict,['NIRCam F322W2'])
+    # MIRI/LRS needs source and planet spectra that extend into the mid-IR.
+    # The Fortney grid example above only extends to about 5 microns, so use
+    # the constant-depth setup here.
+    exo_dict['planet']['type'] = 'constant'
+    exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0
+    exo_dict['planet']['td_unit'] = 's'
+    exo_dict['planet']['radius'] = 1
+    exo_dict['planet']['r_unit'] = 'R_jup'
+    exo_dict['star']['radius'] = 1
+    exo_dict['star']['r_unit'] = 'R_sun'
+    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'
+
+    result = jdi.run_pandexo(exo_dict, ['MIRI LRS'])
+
+Note, you can turn off print statements with ``verbose=False``
+
+The output dictionary can be passed directly to ``justplotit`` to
+inspect the simulated transit or eclipse spectrum and the expected
+precision. Here the spectrum is binned to ``R=100`` for display.
+
+.. code:: ipython3
+
+    wave, spectrum, error = jpi.jwst_1d_spec(result, R=100, num_tran=1, model=False, x_range=[5, 14])
 
 Option 2- Run single instrument mode (with user dict), single planet
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This is the same thing as option 1 but instead of feeding it a list of
 keys, you can feed it a instrument dictionary (this is for users who
@@ -262,24 +341,25 @@ wanted to simulate something NOT pre defined within pandexo)
     result = jdi.run_pandexo(exo_dict, inst_dict)
 
 Option 3- Run several modes, single planet
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use several modes from **print_isntruments()** options.
+Use several modes from **print_instruments()** options.
 
 .. code:: ipython3
 
-    #choose select 
+    #choose select
     result = jdi.run_pandexo(exo_dict,['NIRSpec G140M','NIRSpec G235M','NIRSpec G395M'],
-                   output_file='three_nirspec_modes.p')
-    #run all 
+                   output_file='three_nirspec_modes.p',verbose=True)
+    #run all
     #result = jdi.run_pandexo(exo_dict, ['RUN ALL'], save_file = False)
 
 Option 4- Run single mode, several planet cases
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use a single modes from **print_isntruments()** options. But explore
+Use a single mode from **print_instruments()** options. But explore
 parameter space with respect to **any** parameter in the exo dict. The
-example below shows how to loop over several planet models
+example below uses a few planet radii so the notebook remains runnable
+without external model files.
 
 You can loop through anything in the exoplanet dictionary. It will be
 planet, star or observation followed by whatever you want to loop
@@ -290,95 +370,14 @@ observation+sat_level.. etc
 
 .. code:: ipython3
 
-    #looping over different exoplanet models 
-    jdi.run_pandexo(exo_dict, ['NIRCam F444W'], param_space = 'planet+exopath',
-                    param_range = os.listdir('/path/to/location/of/models'),
-                   output_path = '/path/to/output/simulations')
-    
-    #looping over different stellar temperatures 
-    jdi.run_pandexo(exo_dict, ['NIRCam F444W'], param_space = 'star+temp',
-                    param_range = np.linspace(5000,8000,2),
-                   output_path = '/path/to/output/simulations')
-    
-    #looping over different saturation levels
-    jdi.run_pandexo(exo_dict, ['NIRCam F444W'], param_space = 'observation+sat_level',
-                    param_range = np.linspace(.5,1,5),
-                   output_path = '/path/to/output/simulations')
+    # Loop over a small, self-contained planet-radius grid.
+    # This keeps the example runnable without requiring external model files.
+    exo_dict['planet']['type'] = 'constant'
+    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'
 
-Running PandExo GUI
--------------------
-The same interface that is available online is also available for use on your machine. 
-Using the GUI is very simple and good alternative if editing the input dictionaries is 
-confusing. 
-
-.. code:: bash 
-
-    start_pandexo
-
-Then open up your favorite internet browser and go to: http://localhost:1111
- 
-                   
-Analyzing Output
-----------------
-
-There are pre computed functions for analyzing most common outputs. You can also explore 
-the dictionary structure yourself. 
-
-.. code:: python
-
-    import pandexo.engine.justplotit as jpi
-    import pickle as pk
-
-Plot 1D Data with Errorbars
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Multiple plotting options exist within `jwst\_1d\_spec`
-
-1. Plot a single run
-
-.. code:: python
-
-    #load in output from run
-    out = pk.load(open('singlerun.p','r'))
-    #for a single run 
-    x,y, e = jpi.jwst_1d_spec(out, R=100, num_tran=10, model=False, x_range=[.8,1.28])
-
-.. image:: jwst_1d_spec.png
-
-2. Plot several runs from parameters space run 
-
-.. code:: python
-
-    #load in output from multiple runs
-    multi = pk.load(open('three_nirspec_modes.p','r'))
-
-    #get into list format 
-    list_multi = [multi[0]['NIRSpec G140M'], multi[1]['NIRSpec G235M'], multi[2]['NIRSpec G395M']]
-
-    x,y,e = jpi.jwst_1d_spec(list_multi, R=100, model=False, x_range=[1,5])
-
-.. image:: jwst_1d_spec_multi.png
-
-Plot Noise & More
-~~~~~~~~~~~~~~~~~
-
-Several functions exist to plot various outputs.
-
-See also **jwst\_1d\_bkg**, **jwst\_1d\_snr**, **jwst\_1d\_flux**,
-
-.. code:: python
-
-    x,y = jpi.jwst_noise(out)
-
-.. image:: jwst_noise.png
-
-Plot 2D Detector Profile
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-See also **jwst\_2d\_sat** to plot saturation profile
-
-.. code:: python
-
-    data = jpi.jwst_2d_det(out)
-
-.. image:: jwst_1d_det.png
+    radius_grid = np.linspace(0.8, 1.2, 3)
+    radius_results = jdi.run_pandexo(exo_dict, ['NIRCam F444W'],
+                                    param_space='planet+radius',
+                                    param_range=radius_grid,
+                                    save_file=False,
+                                    verbose=True)

--- a/notebooks/JWST_Running_Pandexo.ipynb
+++ b/notebooks/JWST_Running_Pandexo.ipynb
@@ -36,6 +36,7 @@
     "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
     "import pandexo.engine.justdoit as jdi # THIS IS THE HOLY GRAIL OF PANDEXO\n",
+    "import pandexo.engine.justplotit as jpi\n",
     "import numpy as np\n",
     "import os\n",
     "#pip install pandexo.engine --upgrade"
@@ -93,17 +94,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exo_dict['observation']['sat_level'] = 80    #saturation level in percent of full well \n",
+    "exo_dict['observation']['sat_level'] = 80    #saturation level in percent of full well\n",
     "exo_dict['observation']['sat_unit'] = '%'\n",
-    "exo_dict['observation']['noccultations'] = 1 #number of transits \n",
-    "exo_dict['observation']['R'] = None          #fixed binning. I usually suggest ZERO binning.. you can always bin later \n",
+    "exo_dict['observation']['noccultations'] = 1 #number of transits\n",
+    "exo_dict['observation']['R'] = None          #fixed binning. I usually suggest ZERO binning.. you can always bin later\n",
     "                                             #without having to redo the calcualtion\n",
     "exo_dict['observation']['baseline_unit'] = 'total'  #Defines how you specify out of transit observing time\n",
-    "                                                    #'frac' : fraction of time in transit versus out = in/out \n",
+    "                                                    #'frac' : fraction of time in transit versus out = in/out\n",
     "                                                    #'total' : total observing time (seconds)\n",
     "exo_dict['observation']['baseline'] = 4.0*60.0*60.0 #in accordance with what was specified above (total observing time)\n",
     "\n",
-    "exo_dict['observation']['noise_floor'] = 0   #this can be a fixed level or it can be a filepath \n",
+    "exo_dict['observation']['noise_floor'] = 0   #this can be a fixed level or it can be a filepath\n",
     "                                             #to a wavelength dependent noise floor solution (units are ppm)"
    ]
   },
@@ -126,9 +127,9 @@
    "source": [
     "#OPTION 1 get start from database\n",
     "exo_dict['star']['type'] = 'phoenix'        #phoenix or user (if you have your own)\n",
-    "exo_dict['star']['mag'] = 8.0               #magnitude of the system\n",
+    "exo_dict['star']['mag'] = 10.0              #magnitude of the system\n",
     "exo_dict['star']['ref_wave'] = 1.25         #For J mag = 1.25, H = 1.6, K =2.22.. etc (all in micron)\n",
-    "exo_dict['star']['temp'] = 5500             #in K \n",
+    "exo_dict['star']['temp'] = 5500             #in K\n",
     "exo_dict['star']['metal'] = 0.0             # as log Fe/H\n",
     "exo_dict['star']['logg'] = 4.0              #log surface gravity cgs"
    ]
@@ -149,7 +150,7 @@
     "#Let's create a little fake stellar input\n",
     "\n",
     "import scipy.constants as sc\n",
-    "wl = np.linspace(0.8, 5, 3000)\n",
+    "wl = np.linspace(0.5, 15, 3000)\n",
     "nu = sc.c/(wl*1e-6)  # frequency in sec^-1\n",
     "teff = 5500.0\n",
     "planck_5500K = nu**3 / (np.exp(sc.h*nu/sc.k/teff) - 1)\n",
@@ -162,10 +163,10 @@
     "#    for w,f in zip(wl, planck_5500K):\n",
     "#        sf.write(f'{w:.15f}   {f:.15e}\\n')\n",
     "\n",
-    "exo_dict['star']['type'] = 'user' \n",
-    "exo_dict['star']['mag'] = 8.0               #magnitude of the system\n",
-    "exo_dict['star']['ref_wave'] = 1.25 \n",
-    "exo_dict['star']['starpath'] = starflux   \n",
+    "exo_dict['star']['type'] = 'user'\n",
+    "exo_dict['star']['mag'] = 10.0              #magnitude of the system\n",
+    "exo_dict['star']['ref_wave'] = 1.25\n",
+    "exo_dict['star']['starpath'] = starflux\n",
     "exo_dict['star']['w_unit'] = 'um'\n",
     "exo_dict['star']['f_unit'] = 'erg/cm2/s/Hz'"
    ]
@@ -201,8 +202,8 @@
     "#exo_dict['planet']['exopath'] = {'f':spectrum, 'w':wavelength}\n",
     "\n",
     "exo_dict['planet']['w_unit'] = 'cm'                      #other options include \"um\",\"nm\" ,\"Angs\", \"sec\" (for phase curves)\n",
-    "exo_dict['planet']['f_unit'] = 'rp^2/r*^2'               #other options are 'fp/f*' \n",
-    "exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration \n",
+    "exo_dict['planet']['f_unit'] = 'rp^2/r*^2'               #other options are 'fp/f*'\n",
+    "exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration\n",
     "exo_dict['planet']['td_unit'] = 's'                      #Any unit of time in accordance with astropy.units can be added"
    ]
   },
@@ -220,17 +221,17 @@
    "outputs": [],
    "source": [
     "exo_dict['planet']['type'] = 'constant'                  #tells pandexo you want a fixed transit depth\n",
-    "exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration \n",
-    "exo_dict['planet']['td_unit'] = 's' \n",
+    "exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration\n",
+    "exo_dict['planet']['td_unit'] = 's'\n",
     "exo_dict['planet']['radius'] = 1\n",
     "exo_dict['planet']['r_unit'] = 'R_jup'            #Any unit of distance in accordance with astropy.units can be added here\n",
     "exo_dict['star']['radius'] = 1\n",
     "exo_dict['star']['r_unit'] = 'R_sun'              #Same deal with astropy.units here\n",
-    "exo_dict['planet']['f_unit'] = 'rp^2/r*^2'        #this is what you would do for primary transit \n",
+    "exo_dict['planet']['f_unit'] = 'rp^2/r*^2'        #this is what you would do for primary transit\n",
     "\n",
     "#ORRRRR....\n",
-    "#if you wanted to instead to secondary transit at constant temperature \n",
-    "#exo_dict['planet']['f_unit'] = 'fp/f*' \n",
+    "#if you wanted to instead to secondary transit at constant temperature\n",
+    "#exo_dict['planet']['f_unit'] = 'fp/f*'\n",
     "#exo_dict['planet']['temp'] = 1000"
    ]
   },
@@ -249,9 +250,11 @@
    "outputs": [],
    "source": [
     "exo_dict['planet']['type'] = 'grid'                #tells pandexo you want to pull from the grid\n",
+    "exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0\n",
+    "exo_dict['planet']['td_unit'] = 's'\n",
     "exo_dict['planet']['temp'] = 1000                 #grid: 500, 750, 1000, 1250, 1500, 1750, 2000, 2250, 2500\n",
     "exo_dict['planet']['chem'] = 'noTiO'              #options: 'noTiO' and 'eqchem', noTiO is chemical eq. without TiO\n",
-    "exo_dict['planet']['cloud'] = 'ray10'               #options: nothing: '0', \n",
+    "exo_dict['planet']['cloud'] = 'ray10'               #options: nothing: '0',\n",
     "#                                                   Weak, medium, strong scattering: ray10,ray100, ray1000\n",
     "#                                                   Weak, medium, strong cloud: flat1,flat10, flat100\n",
     "exo_dict['planet']['mass'] = 1\n",
@@ -299,12 +302,12 @@
    "source": [
     "inst_dict = jdi.load_mode_dict('NIRSpec G140H')\n",
     "\n",
-    "#loading in instrument dictionaries allow you to personalize some of  \n",
-    "#the fields that are predefined in the templates. The templates have \n",
-    "#the subbarays with the lowest frame times and the readmodes with 1 frame per group. \n",
+    "#loading in instrument dictionaries allow you to personalize some of\n",
+    "#the fields that are predefined in the templates. The templates have\n",
+    "#the subbarays with the lowest frame times and the readmodes with 1 frame per group.\n",
     "#if that is not what you want. change these fields\n",
     "\n",
-    "#Try printing this out to get a feel for how it is structured: \n",
+    "#Try printing this out to get a feel for how it is structured:\n",
     "\n",
     "print(inst_dict['configuration'])"
    ]
@@ -315,7 +318,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Another way to display this is to print out the keys \n",
+    "#Another way to display this is to print out the keys\n",
     "inst_dict.keys()"
    ]
   },
@@ -350,8 +353,8 @@
    "source": [
     "#you can try personalizing some of these fields\n",
     "\n",
-    "inst_dict[\"configuration\"][\"detector\"][\"ngroup\"] = 'optimize'   #running \"optimize\" will select the maximum \n",
-    "                                                                #possible groups before saturation. \n",
+    "inst_dict[\"configuration\"][\"detector\"][\"ngroup\"] = 'optimize'   #running \"optimize\" will select the maximum\n",
+    "                                                                #possible groups before saturation.\n",
     "                                                                #You can also write in any integer between 2-65536\n",
     "\n",
     "inst_dict[\"configuration\"][\"detector\"][\"subarray\"] = 'substrip256'   #change the subbaray\n",
@@ -422,7 +425,7 @@
    "metadata": {},
    "source": [
     "### Option 1- Run single instrument mode, single planet\n",
-    "If you forget which instruments are available run **jdi.print_isntruments()** and pick one "
+    "If you forget which instruments are available run **jdi.print_instruments()** and pick one "
    ]
   },
   {
@@ -440,7 +443,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = jdi.run_pandexo(exo_dict, ['NIRCam F444W'])"
+    "# MIRI/LRS needs source and planet spectra that extend into the mid-IR.\n",
+    "# The Fortney grid example above only extends to about 5 microns, so use\n",
+    "# the constant-depth setup here.\n",
+    "exo_dict['planet']['type'] = 'constant'\n",
+    "exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0\n",
+    "exo_dict['planet']['td_unit'] = 's'\n",
+    "exo_dict['planet']['radius'] = 1\n",
+    "exo_dict['planet']['r_unit'] = 'R_jup'\n",
+    "exo_dict['star']['radius'] = 1\n",
+    "exo_dict['star']['r_unit'] = 'R_sun'\n",
+    "exo_dict['planet']['f_unit'] = 'rp^2/r*^2'\n",
+    "\n",
+    "result = jdi.run_pandexo(exo_dict, ['MIRI LRS'])"
    ]
   },
   {
@@ -448,6 +463,22 @@
    "metadata": {},
    "source": [
     "Note, you can turn off print statements with `verbose=False`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output dictionary can be passed directly to `justplotit` to inspect the simulated transit or eclipse spectrum and the expected precision. Here the spectrum is binned to `R=100` for display."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wave, spectrum, error = jpi.jwst_1d_spec(result, R=100, num_tran=1, model=False, x_range=[5, 14])"
    ]
   },
   {
@@ -475,7 +506,7 @@
    "metadata": {},
    "source": [
     "### Option 3- Run several modes, single planet\n",
-    "Use several modes from **print_isntruments()** options. "
+    "Use several modes from **print_instruments()** options. "
    ]
   },
   {
@@ -484,10 +515,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#choose select \n",
+    "#choose select\n",
     "result = jdi.run_pandexo(exo_dict,['NIRSpec G140M','NIRSpec G235M','NIRSpec G395M'],\n",
     "               output_file='three_nirspec_modes.p',verbose=True)\n",
-    "#run all \n",
+    "#run all\n",
     "#result = jdi.run_pandexo(exo_dict, ['RUN ALL'], save_file = False)"
    ]
   },
@@ -496,7 +527,7 @@
    "metadata": {},
    "source": [
     "### Option 4- Run single mode, several planet cases\n",
-    "Use a single modes from **print_isntruments()** options. But explore parameter space with respect to **any** parameter in the exo dict. The example below shows how to loop over several planet models\n",
+    "Use a single mode from **print_instruments()** options. But explore parameter space with respect to **any** parameter in the exo dict. The example below uses a few planet radii so the notebook remains runnable without external model files.\n",
     "\n",
     "You can loop through anything in the exoplanet dictionary. It will be planet, star or observation followed by whatever you want to loop through in that set. \n",
     "\n",
@@ -509,20 +540,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#looping over different exoplanet models \n",
-    "jdi.run_pandexo(exo_dict, ['NIRCam F444W'], param_space = 'planet+exopath',\n",
-    "                param_range = os.listdir('/path/to/location/of/models'),\n",
-    "               output_path = '/path/to/output/simulations')\n",
+    "# Loop over a small, self-contained planet-radius grid.\n",
+    "# This keeps the example runnable without requiring external model files.\n",
+    "exo_dict['planet']['type'] = 'constant'\n",
+    "exo_dict['planet']['f_unit'] = 'rp^2/r*^2'\n",
     "\n",
-    "#looping over different stellar temperatures \n",
-    "jdi.run_pandexo(exo_dict, ['NIRCam F444W'], param_space = 'star+temp',\n",
-    "                param_range = np.linspace(5000,8000,2),\n",
-    "               output_path = '/path/to/output/simulations')\n",
-    "\n",
-    "#looping over different saturation levels\n",
-    "jdi.run_pandexo(exo_dict, ['NIRCam F444W'], param_space = 'observation+sat_level',\n",
-    "                param_range = np.linspace(.5,1,5),\n",
-    "               output_path = '/path/to/output/simulations')\n"
+    "radius_grid = np.linspace(0.8, 1.2, 3)\n",
+    "radius_results = jdi.run_pandexo(exo_dict, ['NIRCam F444W'],\n",
+    "                                param_space='planet+radius',\n",
+    "                                param_range=radius_grid,\n",
+    "                                save_file=False,\n",
+    "                                verbose=True)"
    ]
   }
  ],

--- a/notebooks/JWST_Running_Pandexo_w_ExoMAST.ipynb
+++ b/notebooks/JWST_Running_Pandexo_w_ExoMAST.ipynb
@@ -308,7 +308,7 @@
    "metadata": {},
    "source": [
     "### Option 1- Run single instrument mode, single planet\n",
-    "If you forget which instruments are available run **jdi.print_isntruments()** and pick one "
+    "If you forget which instruments are available run **jdi.print_instruments()** and pick one "
    ]
   },
   {
@@ -363,7 +363,7 @@
    "metadata": {},
    "source": [
     "### Option 3- Run several modes, single planet\n",
-    "Use several modes from **print_isntruments()** options. "
+    "Use several modes from **print_instruments()** options. "
    ]
   },
   {
@@ -384,7 +384,7 @@
    "metadata": {},
    "source": [
     "### Option 4- Run single mode, several planet cases\n",
-    "Use a single modes from **print_isntruments()** options. But explore parameter space with respect to **any** parameter in the exo dict. The example below shows how to loop over several planet models\n",
+    "Use a single modes from **print_instruments()** options. But explore parameter space with respect to **any** parameter in the exo dict. The example below shows how to loop over several planet models\n",
     "\n",
     "You can loop through anything in the exoplanet dictionary. It will be planet, star or observation followed by whatever you want to loop through in that set. \n",
     "\n",

--- a/pandexo/engine/create_input.py
+++ b/pandexo/engine/create_input.py
@@ -247,11 +247,15 @@ def bothTrans(out_trans, planet,star=None) :
             planet['flat'] = 0 
             planet['ray'] = 0 
 
-        #we are only using gravity of 25 and scaling by mass from there 
-        fort_grav = 25.0*u.m/u.s/u.s
+        #we are only using gravity of 25 m/s2 and scaling by mass from there
+        fort_grav = 25.0
+        fort_grav_unit = fort_grav*u.m/u.s/u.s
         df = header.loc[(header.gravity==fort_grav) & (header.temp==planet['temp'])
                            & (header.noTiO==planet['noTiO']) & (header.ray==planet['ray']) &
                            (header.flat==planet['flat'])]
+        if len(df) == 0:
+            raise ValueError('No Fortney grid model found for temp={}, chem={}, cloud={}'.format(
+                planet['temp'], planet['chem'], planet['cloud']))
         wave_planet=np.array(pd.read_sql_table(df['name'].values[0],db)['wavelength'])[::-1]
 
         r_lambda=np.array(pd.read_sql_table(df['name'].values[0],db)['radius'])*u.km
@@ -263,11 +267,11 @@ def bothTrans(out_trans, planet,star=None) :
             gravity = c.G*(mass)/(rplan.to(u.m))**2.0 #convert radius to m for gravity units
             #scale lambbda (this technically ignores the fact that scaleheight is altitude dependent)
             #therefore, it will not be valide for very very low gravities
-            z_lambda = z_lambda*fort_grav/gravity
+            z_lambda = z_lambda*fort_grav_unit/gravity
         except: 
             #keep original z lambda 
             gravity=25.0
-            z_lambda = z_lambda*fort_grav/fort_grav
+            z_lambda = z_lambda*fort_grav_unit/fort_grav_unit
             print('Default Planet Gravity of 25 m/s2 given')  
         
         #create new wavelength dependent R based on scaled ravity
@@ -449,11 +453,15 @@ def hst_spec(planet,star) :
             planet['flat'] = 0 
             planet['ray'] = 0 
 
-        #we are only using gravity of 25 and scaling by mass from there 
-        fort_grav = 25.0*u.m/u.s/u.s
+        #we are only using gravity of 25 m/s2 and scaling by mass from there
+        fort_grav = 25.0
+        fort_grav_unit = fort_grav*u.m/u.s/u.s
         df = header.loc[(header.gravity==fort_grav) & (header.temp==planet['temp'])
                            & (header.noTiO==planet['noTiO']) & (header.ray==planet['ray']) &
                            (header.flat==planet['flat'])]
+        if len(df) == 0:
+            raise ValueError('No Fortney grid model found for temp={}, chem={}, cloud={}'.format(
+                planet['temp'], planet['chem'], planet['cloud']))
         wave_planet=np.array(pd.read_sql_table(df['name'].values[0],db)['wavelength'])[::-1]
 
         r_lambda=np.array(pd.read_sql_table(df['name'].values[0],db)['radius'])*u.km
@@ -465,11 +473,11 @@ def hst_spec(planet,star) :
             gravity = c.G*(mass)/(rplan.to(u.m))**2.0 #convert radius to m for gravity units
             #scale lambbda (this technically ignores the fact that scaleheight is altitude dependent)
             #therefore, it will not be valide for very very low gravities
-            z_lambda = z_lambda*fort_grav/gravity
+            z_lambda = z_lambda*fort_grav_unit/gravity
         except: 
             #keep original z lambda 
             gravity=25.0
-            z_lambda = z_lambda*fort_grav/fort_grav
+            z_lambda = z_lambda*fort_grav_unit/fort_grav_unit
             print('Default Planet Gravity of 25 m/s2 given')  
         
         #create new wavelength dependent R based on scaled ravity

--- a/pandexo/engine/justdoit.py
+++ b/pandexo/engine/justdoit.py
@@ -1,4 +1,24 @@
 import numpy as np
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message="pkg_resources is deprecated as an API.*",
+    module="pandeia.engine.config",
+)
+warnings.filterwarnings(
+    "ignore",
+    message='"Reader" was deprecated.*',
+    module="pandeia.engine.extinction",
+)
+warnings.filterwarnings(
+    "ignore",
+    # Pandeia's report formatter evaluates log(0) before checking for zero.
+    message="divide by zero encountered in log",
+    category=RuntimeWarning,
+    module="pandeia.engine.report",
+)
+
 from pandeia.engine.instrument_factory import InstrumentFactory
 from .pandexo import wrapper
 from .load_modes import SetDefaultModes
@@ -297,7 +317,8 @@ def run_param_space(i,exo,inst,param_space, verbose=False):
     #load in correct dict format
     inst_dict = load_mode_dict(inst)
     name = os.path.split(str(i))[1]
-    return {name: wrapper({"pandeia_input": inst_dict , "pandexo_input":exo}, verbose=verbose)}
+    run_verbose = "{}={}".format(param_space, name) if verbose else False
+    return {name: wrapper({"pandeia_input": inst_dict , "pandexo_input":exo}, verbose=run_verbose)}
 
 def run_inst_space(inst,exo, verbose=False):
     """Changes inst dictionary and submits run
@@ -322,7 +343,8 @@ def run_inst_space(inst,exo, verbose=False):
     """
     #load in correct dict format
     inst_dict = load_mode_dict(inst)
-    return {inst: wrapper({"pandeia_input": inst_dict , "pandexo_input":exo}, verbose=verbose)}
+    run_verbose = inst if verbose else False
+    return {inst: wrapper({"pandeia_input": inst_dict , "pandexo_input":exo}, verbose=run_verbose)}
 
 
 def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
@@ -418,9 +440,12 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
             return results
 
         #if there are parameters to cycle through this will run
-        if verbose: print("Running through exo parameters in parallel: " + param_space)
+        if verbose: print("Running through exo parameters in parallel: " + param_space, flush=True)
         #run the above function in parallel
-        results = Parallel(n_jobs=num_cores)(delayed(run_param_space)(i,exo,inst[0],param_space) for i in param_range)
+        results = Parallel(n_jobs=num_cores)(
+            delayed(run_param_space)(i, exo, inst[0], param_space, verbose=verbose) for i in param_range
+        )
+        if verbose: print("Finished exo parameter grid", flush=True)
 
         #Default dump all results [an array of dictionaries] into single file
         #and return results immediately to user
@@ -431,10 +456,13 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         return results
 
     #run several different instrument modes and single planet
-    if verbose: print("Running select instruments")
     if len(inst)>1:
+        if verbose: print("Running select instruments: " + ", ".join(inst), flush=True)
 
-        results = Parallel(n_jobs=num_cores)(delayed(run_inst_space)(i, exo) for i in inst)
+        results = Parallel(n_jobs=num_cores)(
+            delayed(run_inst_space)(i, exo, verbose=verbose) for i in inst
+        )
+        if verbose: print("Finished select instruments", flush=True)
 
         #Default dump all results [an array of dictionaries] into single file
         #and return results immediately to user
@@ -445,8 +473,11 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
 
     #cycle through all options
     elif inst[0].lower() == 'run all':
-        if verbose: print("Running through all instruments")
-        results = Parallel(n_jobs=num_cores)(delayed(run_inst_space)(i, exo) for i in ALL.keys())
+        if verbose: print("Running through all instruments", flush=True)
+        results = Parallel(n_jobs=num_cores)(
+            delayed(run_inst_space)(i, exo, verbose=verbose) for i in ALL.keys()
+        )
+        if verbose: print("Finished running all instruments", flush=True)
 
         #Default dump all results [an array of dictionaries] into single file
         #and return results immediately to user

--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -6,6 +6,7 @@ import pickle as pk
 import numpy as np
 from bokeh.layouts import row
 import pandas as pd
+from copy import copy
 def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', output_file = 'data.html',legend = False,
         R=False,  num_tran = False, plot_width=800, plot_height=400,x_range=[1,10],y_range=None, plot=True,
         output_notebook=True):
@@ -237,6 +238,12 @@ def bin_wave_to_R(w, R):
     >>> print(len(newwave))
     11
     """
+    w = copy(w)
+    reverse = False
+    if w[0] > w[1]:
+        # Need to reverse-sort MIRI data
+        w = w[::-1]
+        reverse = True
     wave = []
     tracker = min(w)
     i = 1
@@ -264,6 +271,10 @@ def bin_wave_to_R(w, R):
         else:
             tracker = max(w)
             wave += [tracker]
+
+    wave = np.array(wave)
+    if reverse:
+        wave = wave[::-1]
     return wave
 
 def uniform_tophat_sum(xnew,x, y):
@@ -293,7 +304,16 @@ def uniform_tophat_sum(xnew,x, y):
     >>> newy
     array([ 240.,  250.,  130.])
     """
-    xnew = np.array(xnew)
+    xnew = copy(xnew)
+    x = copy(x)
+    y = copy(y)
+    reverse = False
+    if x[0] > x[1]:
+        # Need to reverse-sort MIRI data
+        xnew = xnew[::-1]
+        x = x[::-1]
+        y = y[::-1]
+        reverse = True
     szmod=xnew.shape[0]
     delta=np.zeros(szmod)
     ynew=np.zeros(szmod)
@@ -306,6 +326,8 @@ def uniform_tophat_sum(xnew,x, y):
         ynew[i]=np.sum(y[loc])
     loc=np.where((x > xnew[0]-0.5*delta[0]) & (x < xnew[0]+0.5*delta[0]))
     ynew[0]=np.sum(y[loc])
+    if reverse:
+        ynew = ynew[::-1]
     return ynew
 
 def uniform_tophat_mean(xnew,x, y):
@@ -335,7 +357,16 @@ def uniform_tophat_mean(xnew,x, y):
     >>> newy
     array([ 240.,  250.,  130.])
     """
-    xnew = np.array(xnew)
+    xnew = copy(xnew)
+    x = copy(x)
+    y = copy(y)
+    reverse = False
+    if x[0] > x[1]:
+        # Need to reverse-sort MIRI data
+        xnew = xnew[::-1]
+        x = x[::-1]
+        y = y[::-1]
+        reverse = True
     szmod=xnew.shape[0]
     delta=np.zeros(szmod)
     ynew=np.zeros(szmod)
@@ -348,6 +379,8 @@ def uniform_tophat_mean(xnew,x, y):
         ynew[i]=np.mean(y[loc])
     loc=np.where((x > xnew[0]-0.5*delta[0]) & (x < xnew[0]+0.5*delta[0]))
     ynew[0]=np.mean(y[loc])
+    if reverse:
+        ynew = ynew[::-1]
     return ynew
 
 def jwst_1d_flux(result_dict, plot=True, output_file= 'flux.html'):

--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -6,7 +6,6 @@ import pickle as pk
 import numpy as np
 from bokeh.layouts import row
 import pandas as pd
-from copy import copy
 def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', output_file = 'data.html',legend = False,
         R=False,  num_tran = False, plot_width=800, plot_height=400,x_range=[1,10],y_range=None, plot=True,
         output_notebook=True):
@@ -238,12 +237,6 @@ def bin_wave_to_R(w, R):
     >>> print(len(newwave))
     11
     """
-    w = copy(w)
-    reverse = False
-    if w[0] > w[1]:
-        # Need to reverse-sort MIRI data
-        w = w[::-1]
-        reverse = True
     wave = []
     tracker = min(w)
     i = 1
@@ -271,10 +264,6 @@ def bin_wave_to_R(w, R):
         else:
             tracker = max(w)
             wave += [tracker]
-
-    wave = np.array(wave)
-    if reverse:
-        wave = wave[::-1]
     return wave
 
 def uniform_tophat_sum(xnew,x, y):
@@ -304,16 +293,7 @@ def uniform_tophat_sum(xnew,x, y):
     >>> newy
     array([ 240.,  250.,  130.])
     """
-    xnew = copy(xnew)
-    x = copy(x)
-    y = copy(y)
-    reverse = False
-    if x[0] > x[1]:
-        # Need to reverse-sort MIRI data
-        xnew = xnew[::-1]
-        x = x[::-1]
-        y = y[::-1]
-        reverse = True
+    xnew = np.array(xnew)
     szmod=xnew.shape[0]
     delta=np.zeros(szmod)
     ynew=np.zeros(szmod)
@@ -326,8 +306,6 @@ def uniform_tophat_sum(xnew,x, y):
         ynew[i]=np.sum(y[loc])
     loc=np.where((x > xnew[0]-0.5*delta[0]) & (x < xnew[0]+0.5*delta[0]))
     ynew[0]=np.sum(y[loc])
-    if reverse:
-        ynew = ynew[::-1]
     return ynew
 
 def uniform_tophat_mean(xnew,x, y):
@@ -357,16 +335,7 @@ def uniform_tophat_mean(xnew,x, y):
     >>> newy
     array([ 240.,  250.,  130.])
     """
-    xnew = copy(xnew)
-    x = copy(x)
-    y = copy(y)
-    reverse = False
-    if x[0] > x[1]:
-        # Need to reverse-sort MIRI data
-        xnew = xnew[::-1]
-        x = x[::-1]
-        y = y[::-1]
-        reverse = True
+    xnew = np.array(xnew)
     szmod=xnew.shape[0]
     delta=np.zeros(szmod)
     ynew=np.zeros(szmod)
@@ -379,8 +348,6 @@ def uniform_tophat_mean(xnew,x, y):
         ynew[i]=np.mean(y[loc])
     loc=np.where((x > xnew[0]-0.5*delta[0]) & (x < xnew[0]+0.5*delta[0]))
     ynew[0]=np.mean(y[loc])
-    if reverse:
-        ynew = ynew[::-1]
     return ynew
 
 def jwst_1d_flux(result_dict, plot=True, output_file= 'flux.html'):

--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -2,10 +2,34 @@ from bokeh.plotting import show
 from bokeh.plotting import figure as Figure
 from bokeh.io import output_file as outputfile
 from bokeh.io import output_notebook  as outnotebook
+from bokeh.embed import file_html
+from bokeh.resources import CDN
 import pickle as pk
 import numpy as np
 from bokeh.layouts import row
 import pandas as pd
+
+
+def _show_bokeh(plot_obj, output_file, output_notebook):
+    if output_notebook:
+        try:
+            outnotebook()
+            show(plot_obj)
+            return
+        except TypeError as exc:
+            if 'publish_display_data' not in str(exc):
+                raise
+            try:
+                from IPython.display import HTML, display
+                display(HTML(file_html(plot_obj, CDN, output_file)))
+                return
+            except Exception:
+                pass
+
+    outputfile(output_file)
+    show(plot_obj)
+
+
 def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', output_file = 'data.html',legend = False,
         R=False,  num_tran = False, plot_width=800, plot_height=400,x_range=[1,10],y_range=None, plot=True,
         output_notebook=True):
@@ -71,10 +95,6 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
     outy=[]
     oute=[]
     TOOLS = "pan,wheel_zoom,box_zoom,reset,save"
-    if output_notebook & plot:
-        outnotebook()
-    elif plot:
-        outputfile(output_file)
     colors = ['black','blue','red','orange','yellow','purple','pink','cyan','grey','brown']
     #make sure its iterable
     if type(result_dict) != list:
@@ -211,7 +231,7 @@ def jwst_1d_spec(result_dict, model=True, title='Model + Data + Error Bars', out
         fig1d.multi_line(x_err, y_err,color=colors[i])
         i += 1
     if plot:
-        show(fig1d)
+        _show_bokeh(fig1d, output_file, output_notebook)
     return outx,outy,oute
 
 

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -22,6 +22,16 @@ min_nint_trans = 1
 #refdata directory
 default_refdata_directory = os.environ.get("pandeia_refdata")
 
+def sort_by_wave_order(value, wave_order):
+    if isinstance(value, np.ndarray) and value.shape[:1] == (len(wave_order),):
+        return value[wave_order]
+    if isinstance(value, list):
+        return [sort_by_wave_order(item, wave_order) for item in value]
+    if isinstance(value, tuple):
+        return tuple(sort_by_wave_order(item, wave_order) for item in value)
+    return value
+
+
 def compute_full_sim(dictinput,verbose=False): 
     """Top level function to set up exoplanet obs. for JW
     
@@ -62,6 +72,12 @@ def compute_full_sim(dictinput,verbose=False):
     """
     pandeia_input = dictinput['pandeia_input']
     pandexo_input = dictinput['pandexo_input']    	
+
+    def log(message):
+        if isinstance(verbose, str):
+            print("[{}] {}".format(verbose, message), flush=True)
+        elif verbose:
+            print(message, flush=True)
 	
     #define the calculation we'll be doing 
     if pandexo_input['planet']['w_unit'] == 'sec':
@@ -154,32 +170,32 @@ def compute_full_sim(dictinput,verbose=False):
             "nframe":nframe,"mingroups":mingroups,"nskip":nskip}
     else:
         #run pandeia once to determine max exposure time per int and get exposure params
-        if verbose: print("Optimization Reqested: Computing Duty Cycle")
+        log("Optimization Reqested: Computing Duty Cycle")
         m = {"maxexptime_per_int":compute_maxexptime_per_int(pandeia_input, sat_level) , 
             "tframe":tframe,"nframe":nframe,"mingroups":mingroups,"nskip":nskip}
-        if verbose: print("Finished Duty Cycle Calc")
+        log("Finished Duty Cycle Calc")
 
     #calculate all timing info
     timing, flags = compute_timing(m,transit_duration,expfact_out,noccultations)
     
     #Simulate out trans and in transit
-    if verbose: print("Starting Out of Transit Simulation")
+    log("Starting Out of Transit Simulation")
     out = perform_out(pandeia_input, pandexo_input,timing, both_spec)
     
     #extract extraction area before dict conversion
     extraction_area = out.extraction_area
     out = out.as_dict()
     out.pop('3d')
-    if verbose: print("End out of Transit")
+    log("End out of Transit")
 
     #Remove effects of Quantum Yield from shot noise 
     out = remove_QY(out, instrument)
 
     #this kind of redundant going to compute inn from out instead 
     #keep perform_in but change inputs to (out, timing, both_spec)
-    if verbose: print("Starting In Transit Simulation")
+    log("Starting In Transit Simulation")
     inn = perform_in(pandeia_input, pandexo_input,timing, both_spec, out, calculation)
-    if verbose: print("End In Transit")
+    log("End In Transit")
     
 
 
@@ -223,6 +239,16 @@ def compute_full_sim(dictinput,verbose=False):
     varout = result['var_out_1d']
     extracted_flux_out = result['photon_out_1d']
     extracted_flux_inn = result['photon_in_1d']
+
+    input_wave_order = np.argsort(w, kind='mergesort')
+    if not np.array_equal(input_wave_order, np.arange(len(w))):
+        w = w[input_wave_order]
+        varin = varin[input_wave_order]
+        varout = varout[input_wave_order]
+        extracted_flux_out = extracted_flux_out[input_wave_order]
+        extracted_flux_inn = extracted_flux_inn[input_wave_order]
+        result['rn[out,in]'] = sort_by_wave_order(result['rn[out,in]'], input_wave_order)
+        result['bkg[out,in]'] = sort_by_wave_order(result['bkg[out,in]'], input_wave_order)
 
         
     #bin the data according to user input 
@@ -281,6 +307,18 @@ def compute_full_sim(dictinput,verbose=False):
     if pandexo_input['planet']['f_unit'] == 'fp/f*':
         sim_spec = -1.0*sim_spec
         raw_spec = -1.0*raw_spec    
+
+    wave_order = np.argsort(wbin, kind='mergesort')
+    if not np.array_equal(wave_order, np.arange(len(wbin))):
+        wbin = wbin[wave_order]
+        photon_out_bin = photon_out_bin[wave_order]
+        photon_in_bin = photon_in_bin[wave_order]
+        var_in_bin = var_in_bin[wave_order]
+        var_out_bin = var_out_bin[wave_order]
+        error_spec = error_spec[wave_order]
+        error_spec_nfloor = error_spec_nfloor[wave_order]
+        raw_spec = raw_spec[wave_order]
+        sim_spec = sim_spec[wave_order]
    
     #package processed data
     finalspec = {'wave':wbin,
@@ -297,8 +335,8 @@ def compute_full_sim(dictinput,verbose=False):
                 'e_rate_in':photon_in_bin/ti,
                 'wave':wbin,
                 'error_no_floor':error_spec, 
-                'rn[out,in]':result['rn[out,in]'],
-                'bkg[out,in]':result['bkg[out,in]']
+                'rn[out,in]':sort_by_wave_order(result['rn[out,in]'], wave_order),
+                'bkg[out,in]':sort_by_wave_order(result['bkg[out,in]'], wave_order)
                 }
  
     result_dict = as_dict(out,both_spec ,finalspec, 
@@ -981,4 +1019,3 @@ def as_dict(out, both_spec ,binned, timing, mag, sat_level, warnings, punit, unb
     return final_dict
 
     
-

--- a/run_test.py
+++ b/run_test.py
@@ -26,6 +26,17 @@ exo_dict['planet']['r_unit'] = 'R_jup'
 exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0 
 exo_dict['planet']['td_unit'] = 's'
 exo_dict['planet']['f_unit'] = 'rp^2/r*^2'
+
+
+def assert_sorted_wavelengths(result, inst):
+    wave = np.asarray(result['FinalSpectrum']['wave'])
+    assert np.all(np.diff(wave) >= 0), f'{inst} produced unsorted wavelengths'
+
+
 print('Starting TEST run')
-jdi.run_pandexo(exo_dict, ['NIRSpec G140H'], save_file=False)
+nirspec_result = jdi.run_pandexo(exo_dict, ['NIRSpec G140H'], save_file=False)
+assert_sorted_wavelengths(nirspec_result, 'NIRSpec G140H')
+
+miri_result = jdi.run_pandexo(exo_dict, ['MIRI LRS'], save_file=False)
+assert_sorted_wavelengths(miri_result, 'MIRI LRS')
 print('SUCCESS') 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,36 @@ except ImportError:
     from setuptools import setup
 import sys 
 PY_V = sys.version_info
+
+docs_requires = [
+    'sphinx',
+    'sphinx-rtd-theme',
+    'nbconvert',
+    'nbformat',
+]
+
+notebook_requires = [
+    'jupyter',
+    'ipykernel',
+]
+
+test_requires = [
+    'pytest',
+]
+
+build_requires = [
+    'build',
+    'twine',
+    'wheel',
+]
+
+dev_requires = (
+    docs_requires
+    + notebook_requires
+    + test_requires
+    + build_requires
+)
+
 # The standard setup() call.  Notice, however, that most of the arguments
 # normally passed to setup() are absent.  They will instead be read from the
 # setup.cfg file using d2to1.
@@ -90,19 +120,28 @@ setup(
 
     install_requires=[
           'pandeia.engine==3.0',
-          'numpy',
+          'numpy<2',  # Needed to avoid deprecations
           'bokeh==3.0.2',
+          'ipython<9',  # Needed for bokeh==3.0.2 notebook display compatibility
           'tornado',
           'pandas',
           'joblib',
           'photutils',
-          'astropy',
+          'astropy<7',  # Needed to avoid deprecations
           'pysynphot',
+          'setuptools<81',  # Needed for pkg_resources deprecation
           'sqlalchemy',
           'astroquery',
-          'scipy',
+          'scipy<1.15',  # Needed to avoid deprecations
           'batman-package'
           ],
+    extras_require={
+        'docs': docs_requires,
+        'notebooks': notebook_requires,
+        'test': test_requires,
+        'dev': dev_requires,
+        'all': dev_requires,
+    },
     entry_points = {
         'console_scripts':
             ['start_pandexo=pandexo.engine.run_online:main']


### PR DESCRIPTION
## Summary

This PR makes several maintenance updates to improve PandExo's JWST simulation workflow and documentation ahead of Cycle 6 preparation.

The main engine-side change is to make JWST simulation outputs more robust to instrument wavelength-order differences, including the reversed wavelength arrays encountered for MIRI/LRS simulations. The PR also improves error handling around Fortney-grid model retrieval and reduces noisy deprecation-warning output during PandExo runs.

This PR also refreshes the JWST tutorial materials and adds a small docs helper script so the checked-in RST tutorial can be regenerated from the source notebook. In addition, it includes plotting, dependency, and repository-cleanup updates that make local testing and documentation maintenance smoother.

## Main changes

- Sort JWST simulation wavelength outputs for more consistent downstream behavior.
- Add test assertions that verify wavelength arrays are sorted in generated results.
- Improve Fortney-grid retrieval error handling in create_input.py.
- Reduce noisy warning output during PandExo execution.
- Update JWST tutorial notebooks, including justplotit spectrum visualization usage.
- Add tooling to regenerate/check the JWST tutorial RST from its source notebook.
- Clean up Bokeh plotting code in justplotit.py.
- Expand setup dependencies needed for docs/testing/development workflows.
- Update .gitignore for common Python, notebook, build, cache, and generated-output artifacts.

## Notes for review

The original motivation was fixing MIRI/LRS behavior when the wavelength array is reversed, which affected wavelength-binning/plotting behavior for simulations with finite resolving power. The PR has since grown into a broader maintenance update for JWST PandExo usage, so review should include both the science-output behavior and the tutorial/docs changes.