### PR TITLE
Improve JWST plotting, timing tables, and browser calculation behavior

### DIFF
--- a/pandexo/engine/compute_noise.py
+++ b/pandexo/engine/compute_noise.py
@@ -382,6 +382,16 @@ class ExtractSpec():
         extracted_flux_inn = curves_inn['extracted_flux'][1] * self.nint_in
 
         extracted_flux_out = curves_out['extracted_flux'][1] * self.nint_out
+        extracted_flux_per_int_inn = (
+            curves_inn['extracted_flux'][1]
+            * self.inn.get('scalar', self.out['scalar'])['measurement_time']
+            / float(self.nsuperstripe)
+        )
+        extracted_flux_per_int_out = (
+            curves_out['extracted_flux'][1]
+            * self.out['scalar']['measurement_time']
+            / float(self.nsuperstripe)
+        )
 
         extracted_noise_inn = curves_inn['extracted_noise'][1] * np.sqrt(self.nint_in)
 
@@ -395,7 +405,9 @@ class ExtractSpec():
         varin = extracted_noise_inn**2
         varout = extracted_noise_out**2
 
-        return {'photon_out_1d':extracted_flux_out, 'photon_in_1d':extracted_flux_inn, 
+        return {'photon_out_1d':extracted_flux_out, 'photon_in_1d':extracted_flux_inn,
+                    'photon_out_1d_per_int':extracted_flux_per_int_out,
+                    'photon_in_1d_per_int':extracted_flux_per_int_inn,
                     'var_in_1d':varin, 'var_out_1d': varout,'on_source_in':self.on_source_in, 
                 'on_source_out':self.on_source_out,'bkg[out,in]':[bkg_flux_out,bkg_flux_inn],
                 'rn[out,in]':[rn_var_out,rn_var_inn], 
@@ -436,6 +448,16 @@ class ExtractSpec():
         #extract fluxs
         extracted_flux_inn = curves_inn['extracted_flux'][1] * on_source_in 
         extracted_flux_out = curves_out['extracted_flux'][1] * on_source_out 
+        extracted_flux_per_int_inn = (
+            curves_inn['extracted_flux'][1]
+            * self.inn.get('scalar', self.out['scalar'])['measurement_time']
+            / float(self.nsuperstripe)
+        )
+        extracted_flux_per_int_out = (
+            curves_out['extracted_flux'][1]
+            * self.out['scalar']['measurement_time']
+            / float(self.nsuperstripe)
+        )
                 
         #background + contamination extracted 
         bkg_flux_inn = curves_inn['extracted_bg_only'][1] * on_source_in 
@@ -445,7 +467,9 @@ class ExtractSpec():
         varin = (extracted_flux_inn + bkg_flux_inn + rn_var_inn)
         varout = (extracted_flux_out + bkg_flux_out + rn_var_out)
         
-        return {'photon_out_1d':extracted_flux_out, 'photon_in_1d':extracted_flux_inn, 
+        return {'photon_out_1d':extracted_flux_out, 'photon_in_1d':extracted_flux_inn,
+                    'photon_out_1d_per_int':extracted_flux_per_int_out,
+                    'photon_in_1d_per_int':extracted_flux_per_int_inn,
                     'var_in_1d':varin, 'var_out_1d': varout,'on_source_in':self.on_source_in, 
                 'on_source_out':self.on_source_out, 'rn[out,in]':[rn_var_out,rn_var_inn], 
                 'bkg[out,in]':[bkg_flux_out,bkg_flux_inn], 

--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -8,6 +8,7 @@ import pickle as pk
 import numpy as np
 from bokeh.layouts import row
 import pandas as pd
+from .utils.plot_helpers import add_wavelength_gap_breaks
 
 CIRCLE_SIZE = 6
 
@@ -404,12 +405,13 @@ def jwst_1d_flux(result_dict, plot=True, output_file= 'flux.html'):
     x, y = out['1d']['extracted_flux']
     x = x[~np.isnan(y)]
     y = y[~np.isnan(y)]
+    x_plot, y_plot = add_wavelength_gap_breaks(x, y)
 
     plot_flux_1d1 = Figure(#tools=TOOLS,
                          x_axis_label='Wavelength [microns]',
                          y_axis_label='Flux (e/s)', title="Out of Transit Flux Rate",
                          width=800, height=300)
-    plot_flux_1d1.line(x, y, line_width = 4, alpha = .7)
+    plot_flux_1d1.line(x_plot, y_plot, line_width = 4, alpha = .7)
 
     if plot:
         outputfile(output_file)
@@ -448,11 +450,12 @@ def jwst_1d_snr(result_dict, plot=True, output_file='snr.html'):
     y = electrons_out/np.sqrt(result_dict['RawData']['var_out'])
     x = x[~np.isnan(y)]
     y = y[~np.isnan(y)]
+    x_plot, y_plot = add_wavelength_gap_breaks(x, y)
     plot_snr_1d1 = Figure(#tools=TOOLS,
                          x_axis_label='Wavelength (micron)',
                          y_axis_label='SNR', title="SNR Out of Trans",
                          width=800, height=300)
-    plot_snr_1d1.line(x, y, line_width = 4, alpha = .7)
+    plot_snr_1d1.line(x_plot, y_plot, line_width = 4, alpha = .7)
     if plot:
         outputfile(output_file)
         show(plot_snr_1d1)
@@ -529,6 +532,7 @@ def jwst_noise(result_dict, plot=True, output_file= 'noise.html'):
     y = result_dict['FinalSpectrum']['error_w_floor']*1e6
     x = x[~np.isnan(y)]
     y = y[~np.isnan(y)]
+    x_plot, y_plot = add_wavelength_gap_breaks(x, y)
 
     ymed = np.median(y)
 
@@ -538,7 +542,7 @@ def jwst_noise(result_dict, plot=True, output_file= 'noise.html'):
                          y_axis_label='Error on Spectrum (PPM)', title="Error Curve",
                          width=800, height=300, y_range = [0,2.0*ymed])
     ymed = np.median(y)
-    plot_noise_1d1.step(x, y, line_width = 4, alpha = .7)
+    plot_noise_1d1.step(x_plot, y_plot, line_width = 4, alpha = .7)
     if plot:
         outputfile(output_file)
         show(plot_noise_1d1)

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -18,7 +18,7 @@ max_ngroup = {'nirspec':65535,
               'niriss':65535,
               'nircam':100}
 #minimum number of integrations
-min_nint_trans = 1
+min_nint_trans = 3
 DHS_F150W_MIN_WAVELENGTH = 0.96
 
 #refdata directory
@@ -821,17 +821,44 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
             )
             return full_cycle
         return (ngroups+1.0)*tframe
-    overhead_per_int = tframe #overhead time added per integration 
-    try: 
+    def _timing_values(ngroups):
+        if ngroups == 1:
+            frame_zero_dead = 0
+        else:
+            frame_zero_dead = -1
+
+        science_time_per_int = (ngroups + frame_zero_dead)*tframe*(nframe+nskip)
+        measurement_time_per_int = science_time_per_int*nsuperstripe
+        clocktime_per_int = _clocktime_per_int(ngroups)
+        eff = measurement_time_per_int/float(nsuperstripe)/clocktime_per_int
+        nint_per_occultation = transit_duration/clocktime_per_int
+        nint_in = np.ceil(nint_per_occultation)
+        nint_out = np.ceil(nint_in/expfact_out)
+
+        return {
+            "frame_zero_dead": frame_zero_dead,
+            "science_time_per_int": science_time_per_int,
+            "measurement_time_per_int": measurement_time_per_int,
+            "clocktime_per_int": clocktime_per_int,
+            "eff": eff,
+            "nint_per_occultation": nint_per_occultation,
+            "nint_in": nint_in,
+            "nint_out": nint_out,
+            "exptime_per_int": ngroups*tframe,
+        }
+
+    optimized_ngroups = "maxexptime_per_int" in m
+    if optimized_ngroups:
         #are we starting with a exposure time ?
         maxexptime_per_int = m['maxexptime_per_int']
-    except:
+    else:
         #or a pre defined number of groups specified by user
         ngroups_per_int = m['ngroup']
         
     flag_default = "All good"
     flag_high = "All good"
-    if 'maxexptime_per_int' in locals():
+    flag_min_nint = "All good"
+    if optimized_ngroups:
         #Frist, if maxexptime_per_int has been defined (from above), compute ngroups_per_int
         
         #number of frames in one integration is the maximum time beofre exposure 
@@ -870,56 +897,64 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
         nframes_per_int = mingroups
         flag_default = f"Something went wrong. SET TO NGROUPS={mingroups}"
 
-    if ngroups_per_int == 1: 
-        frame_zero_dead = 0 
-    else: 
-        frame_zero_dead = -1
-
-    # FML normally measures the last frame minus the first frame. NGROUP=1
-    # has no true first-last baseline; Pandeia treats it as a measurement
-    # from the superbias frame to the end of the first group. Keep that
-    # positive timing convention while warning users downstream.
-    science_time_per_int = (ngroups_per_int + frame_zero_dead)*tframe*(nframe+nskip)
-    measurement_time_per_int = science_time_per_int*nsuperstripe
-
-    #the integration time is related to the number of groups and the time of each 
-    #group 
-    exptime_per_int = ngroups_per_int*tframe
-    
-    # Clock time includes reset/readout overheads. For multistripe readouts,
-    # Pandeia's exposure_time is the full APT integration cycle across all
-    # stripes; per-wavelength noise scaling is handled by the effective
-    # integration counts below.
-    clocktime_per_int = _clocktime_per_int(ngroups_per_int)
-    
-    #observing efficiency (i.e. what percentage of total time is spent on soure)
-    eff = (ngroups_per_int + frame_zero_dead)/(ngroups_per_int + 1.0)
-    
-    # This says "per occultation" but this is just the in-transit integration
-    # count. For multistripe modes the clock is the full APT integration cycle.
-    nint_per_occultation =  transit_duration/clocktime_per_int
-    
-    #figure out how many integrations are in transit and how many are out of transit 
-    nint_in = np.ceil(nint_per_occultation)
-    nint_out = np.ceil(nint_in/expfact_out)
+    timing_values = _timing_values(ngroups_per_int)
+    frame_zero_dead = timing_values["frame_zero_dead"]
+    science_time_per_int = timing_values["science_time_per_int"]
+    measurement_time_per_int = timing_values["measurement_time_per_int"]
+    exptime_per_int = timing_values["exptime_per_int"]
+    clocktime_per_int = timing_values["clocktime_per_int"]
+    eff = timing_values["eff"]
+    nint_per_occultation = timing_values["nint_per_occultation"]
+    nint_in = timing_values["nint_in"]
+    nint_out = timing_values["nint_out"]
     
     #you would never want a single integration in transit. 
     #here we assume that for very dim things, you would want at least 
     #3 integrations in transit 
     if nint_in < min_nint_trans:
-        ngroups_per_int = np.floor(ngroups_per_int/min_nint_trans)
-        exptime_per_int = (ngroups_per_int)*tframe
-        if ngroups_per_int == 1:
-            frame_zero_dead = 0
+        original_ngroups_per_int = ngroups_per_int
+        original_nint_in = nint_in
+
+        if optimized_ngroups:
+            ngroups_per_int = np.max(
+                [mingroups, np.floor(ngroups_per_int/min_nint_trans)]
+            )
+            timing_values = _timing_values(ngroups_per_int)
+            while (
+                    timing_values["nint_in"] < min_nint_trans and
+                    ngroups_per_int > mingroups):
+                ngroups_per_int -= 1
+                timing_values = _timing_values(ngroups_per_int)
+
+            frame_zero_dead = timing_values["frame_zero_dead"]
+            science_time_per_int = timing_values["science_time_per_int"]
+            measurement_time_per_int = timing_values["measurement_time_per_int"]
+            exptime_per_int = timing_values["exptime_per_int"]
+            clocktime_per_int = timing_values["clocktime_per_int"]
+            eff = timing_values["eff"]
+            nint_per_occultation = timing_values["nint_per_occultation"]
+            nint_in = timing_values["nint_in"]
+            nint_out = timing_values["nint_out"]
+            flag_min_nint = (
+                f"Optimized NGROUPS would produce {int(original_nint_in)} "
+                f"in-transit integrations. Reduced NGROUPS from "
+                f"{int(original_ngroups_per_int)} to {int(ngroups_per_int)} "
+                f"to require at least {min_nint_trans} in-transit integrations."
+            )
+            if nint_in < min_nint_trans:
+                flag_min_nint = (
+                    f"Optimized NGROUPS would produce {int(original_nint_in)} "
+                    f"in-transit integrations. Reduced NGROUPS from "
+                    f"{int(original_ngroups_per_int)} to the minimum allowed "
+                    f"value of {int(ngroups_per_int)}, but this still produces "
+                    f"fewer than {min_nint_trans} in-transit integrations."
+                )
         else:
-            frame_zero_dead = -1
-        science_time_per_int = (ngroups_per_int + frame_zero_dead)*tframe*(nframe+nskip)
-        measurement_time_per_int = science_time_per_int*nsuperstripe
-        clocktime_per_int = _clocktime_per_int(ngroups_per_int)
-        eff = (ngroups_per_int + frame_zero_dead)/(ngroups_per_int + 1.0)
-        nint_per_occultation =  transit_duration/clocktime_per_int
-        nint_in = np.ceil(nint_per_occultation)
-        nint_out = np.ceil(nint_in/expfact_out)
+            flag_min_nint = (
+                f"User-specified NGROUPS produces {int(nint_in)} in-transit "
+                f"integrations, below the recommended minimum of "
+                f"{min_nint_trans}. NGROUPS was not changed."
+            )
         
     if nint_out < min_nint_trans:
         nint_out = min_nint_trans
@@ -956,7 +991,11 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
         "Zero Frame Efficiency Loss":frame_zero_dead
         }      
 
-    return timing, {'flag_default':flag_default,'flag_high':flag_high}
+    return timing, {
+        'flag_default':flag_default,
+        'flag_high':flag_high,
+        'flag_min_nint':flag_min_nint,
+    }
 
 def update_timing_measurement_time(timing, measurement_time_per_int):
     """Sync timing metadata to the measurement_time reported by Pandeia.
@@ -1168,7 +1207,8 @@ def add_warnings(pand_dict, timing, sat_level, flags,instrument):
             "Non linear?" : flag_nonl,
             "Saturated?" : flag_sat,
             "% full well high?": flag_perc, 
-            "Num Groups Reset?": flags["flag_default"]
+            "Num Groups Reset?": flags["flag_default"],
+            "Minimum Integrations?": flags.get("flag_min_nint", "All good")
     }
 
     return warnings     

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -13,10 +13,10 @@ import pickle
 
 #constant parameters.. consider putting these into json file 
 #max groups in integration
-max_ngroup = {'nirspec':65536.0 ,
-              'miri':65536.0 ,
-              'niriss':65536.0 ,
-              'nircam':30}
+max_ngroup = {'nirspec':65535,
+              'miri':65535,
+              'niriss':65535,
+              'nircam':100}
 #minimum number of integrations
 min_nint_trans = 1
 

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -512,6 +512,7 @@ def compute_full_sim(dictinput,verbose=False):
     varout = result['var_out_1d']
     extracted_flux_out = result['photon_out_1d']
     extracted_flux_inn = result['photon_in_1d']
+    extracted_flux_per_int_out = result.get('photon_out_1d_per_int')
     pandeia_extracted_noise = None
     pandeia_snr_int = None
     pandeia_full_saturation = None
@@ -534,6 +535,8 @@ def compute_full_sim(dictinput,verbose=False):
         varout = varout[input_wave_order]
         extracted_flux_out = extracted_flux_out[input_wave_order]
         extracted_flux_inn = extracted_flux_inn[input_wave_order]
+        if extracted_flux_per_int_out is not None:
+            extracted_flux_per_int_out = extracted_flux_per_int_out[input_wave_order]
         result['rn[out,in]'] = sort_by_wave_order(result['rn[out,in]'], input_wave_order)
         result['bkg[out,in]'] = sort_by_wave_order(result['bkg[out,in]'], input_wave_order)
         if pandeia_extracted_noise is not None:
@@ -554,6 +557,8 @@ def compute_full_sim(dictinput,verbose=False):
         varout = varout[valid_channel]
         extracted_flux_out = extracted_flux_out[valid_channel]
         extracted_flux_inn = extracted_flux_inn[valid_channel]
+        if extracted_flux_per_int_out is not None:
+            extracted_flux_per_int_out = extracted_flux_per_int_out[valid_channel]
         pandeia_full_saturation = pandeia_full_saturation[valid_channel]
         result['rn[out,in]'] = sort_by_wave_order(result['rn[out,in]'], valid_channel)
         result['bkg[out,in]'] = sort_by_wave_order(result['bkg[out,in]'], valid_channel)
@@ -568,6 +573,8 @@ def compute_full_sim(dictinput,verbose=False):
         varout = varout[dhs_wavelength_channel]
         extracted_flux_out = extracted_flux_out[dhs_wavelength_channel]
         extracted_flux_inn = extracted_flux_inn[dhs_wavelength_channel]
+        if extracted_flux_per_int_out is not None:
+            extracted_flux_per_int_out = extracted_flux_per_int_out[dhs_wavelength_channel]
         if pandeia_extracted_noise is not None:
             pandeia_extracted_noise = pandeia_extracted_noise[dhs_wavelength_channel]
         if pandeia_full_saturation is not None:
@@ -588,6 +595,14 @@ def compute_full_sim(dictinput,verbose=False):
 
         photon_out_bin = uniform_tophat_sum(wbin, w,extracted_flux_out)
         photon_in_bin = uniform_tophat_sum(wbin,w, extracted_flux_inn)
+        if extracted_flux_per_int_out is None:
+            electron_per_int_bin = photon_out_bin / result.get(
+                'real_nint_out', result.get('nint_out', 1)
+            )
+        else:
+            electron_per_int_bin = uniform_tophat_sum(
+                wbin, w, extracted_flux_per_int_out
+            )
         var_in_bin = uniform_tophat_sum(wbin, w,varin)
         var_out_bin = uniform_tophat_sum(wbin,w, varout)
         full_saturation_bin = (
@@ -597,6 +612,7 @@ def compute_full_sim(dictinput,verbose=False):
         valid_photon = photon_out_bin > 0
         wbin = wbin[valid_photon]
         photon_in_bin = photon_in_bin[valid_photon]
+        electron_per_int_bin = electron_per_int_bin[valid_photon]
         var_in_bin = var_in_bin[valid_photon]
         var_out_bin = var_out_bin[valid_photon]
         full_saturation_bin = full_saturation_bin[valid_photon]
@@ -604,6 +620,12 @@ def compute_full_sim(dictinput,verbose=False):
     else: 
         wbin = w
         photon_out_bin = extracted_flux_out
+        if extracted_flux_per_int_out is None:
+            electron_per_int_bin = photon_out_bin / result.get(
+                'real_nint_out', result.get('nint_out', 1)
+            )
+        else:
+            electron_per_int_bin = extracted_flux_per_int_out
         full_saturation_bin = (
             np.zeros(len(wbin), dtype=bool)
             if pandeia_full_saturation is None
@@ -613,6 +635,7 @@ def compute_full_sim(dictinput,verbose=False):
         wbin = wbin[valid_photon]
         photon_in_bin = extracted_flux_inn
         photon_in_bin = photon_in_bin[valid_photon]
+        electron_per_int_bin = electron_per_int_bin[valid_photon]
         var_in_bin = varin
         var_in_bin = var_in_bin[valid_photon]
         var_out_bin = varout
@@ -659,6 +682,7 @@ def compute_full_sim(dictinput,verbose=False):
         wbin = wbin[wave_order]
         photon_out_bin = photon_out_bin[wave_order]
         photon_in_bin = photon_in_bin[wave_order]
+        electron_per_int_bin = electron_per_int_bin[wave_order]
         var_in_bin = var_in_bin[wave_order]
         var_out_bin = var_out_bin[wave_order]
         error_spec = error_spec[wave_order]
@@ -679,7 +703,7 @@ def compute_full_sim(dictinput,verbose=False):
     rawstuff = {
                 'electrons_out':photon_out_bin*nocc, 
                 'electrons_in':photon_in_bin*nocc,
-                'electron_per_int':photon_out_bin/nint_out, 
+                'electron_per_int':electron_per_int_bin,
                 'snr_int': (
                     pandeia_snr_int
                     if pandeia_snr_int is not None

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -19,6 +19,7 @@ max_ngroup = {'nirspec':65535,
               'nircam':100}
 #minimum number of integrations
 min_nint_trans = 1
+DHS_F150W_MIN_WAVELENGTH = 0.96
 
 #refdata directory
 default_refdata_directory = os.environ.get("pandeia_refdata")
@@ -132,6 +133,46 @@ def nirspec_valid_channel_mask(conf, extracted_noise, full_saturation=None):
         & (full_saturation > 0.0)
     )
     return valid_noise | fully_saturated
+
+
+def dhs_f150w_wavelength_mask(conf, wave):
+    """Build a wavelength mask for the low-throughput edge of DHS F150W.
+
+    NIRCam DHS calculations can include F150W/F150W2 wavelength samples below
+    the useful bandpass where the throughput is effectively zero. Those samples
+    make the raw and binned diagnostic plots difficult to read, so PandExo
+    trims them before downstream binning and plot packaging.
+
+    Parameters
+    ----------
+    conf : dict
+        Pandeia ``configuration`` dictionary for the calculation. The helper
+        inspects ``conf["instrument"]`` to determine whether the setup is a
+        NIRCam DHS calculation with a filter name starting with ``"f150w"``.
+    wave : array-like
+        Wavelength samples in microns.
+
+    Returns
+    -------
+    numpy.ndarray or None
+        Boolean mask selecting wavelengths greater than or equal to
+        ``DHS_F150W_MIN_WAVELENGTH``. Returns ``None`` when the calculation is
+        not a NIRCam DHS F150W/F150W2 setup, so callers can leave other modes
+        unchanged.
+    """
+    instrument = conf.get('instrument', {})
+    if str(instrument.get('instrument', '')).lower() != 'nircam':
+        return None
+
+    aperture = str(instrument.get('aperture', '')).lower()
+    mode = str(instrument.get('mode', '')).lower()
+    filter_name = str(instrument.get('filter', '')).lower()
+    if 'dhs' not in aperture and mode != 'dhs':
+        return None
+    if not filter_name.startswith('f150w'):
+        return None
+
+    return np.asarray(wave, dtype=float) >= DHS_F150W_MIN_WAVELENGTH
 
 
 def _no_valid_spectral_channels_message(conf, scalar):
@@ -519,6 +560,23 @@ def compute_full_sim(dictinput,verbose=False):
         result['rn[out,in]'] = sort_by_wave_order(result['rn[out,in]'], valid_channel)
         result['bkg[out,in]'] = sort_by_wave_order(result['bkg[out,in]'], valid_channel)
         pandeia_snr_int = sort_by_wave_order(pandeia_snr_int, valid_channel)
+
+    dhs_wavelength_channel = None
+    if not is_phase_spec(calculation):
+        dhs_wavelength_channel = dhs_f150w_wavelength_mask(conf, w)
+    if dhs_wavelength_channel is not None:
+        w = w[dhs_wavelength_channel]
+        varin = varin[dhs_wavelength_channel]
+        varout = varout[dhs_wavelength_channel]
+        extracted_flux_out = extracted_flux_out[dhs_wavelength_channel]
+        extracted_flux_inn = extracted_flux_inn[dhs_wavelength_channel]
+        if pandeia_extracted_noise is not None:
+            pandeia_extracted_noise = pandeia_extracted_noise[dhs_wavelength_channel]
+        if pandeia_full_saturation is not None:
+            pandeia_full_saturation = pandeia_full_saturation[dhs_wavelength_channel]
+        result['rn[out,in]'] = sort_by_wave_order(result['rn[out,in]'], dhs_wavelength_channel)
+        result['bkg[out,in]'] = sort_by_wave_order(result['bkg[out,in]'], dhs_wavelength_channel)
+        pandeia_snr_int = sort_by_wave_order(pandeia_snr_int, dhs_wavelength_channel)
 
         
     #bin the data according to user input 

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -195,7 +195,7 @@ def _no_valid_spectral_channels_message(conf, scalar):
         ('sat_ngroups', scalar.get('sat_ngroups')),
     ]:
         if value is not None:
-            details.append('{0}={1}'.format(key, value))
+            details.append(f'{key}={value}')
     return ' '.join(details)
 
 
@@ -204,9 +204,7 @@ def _saturation_warning_message(conf, scalar, pandeia_warning, saturation_kind):
     instrument = conf.get('instrument', {})
     detector = conf.get('detector', {})
     details = [
-        'Pandeia reports {0} saturation for this observation.'.format(
-            saturation_kind
-        ),
+        f'Pandeia reports {saturation_kind} saturation for this observation.',
         str(pandeia_warning),
     ]
     for key, value in [
@@ -220,7 +218,7 @@ def _saturation_warning_message(conf, scalar, pandeia_warning, saturation_kind):
         ('sat_ngroups', scalar.get('sat_ngroups')),
     ]:
         if value is not None:
-            details.append('{0}={1}'.format(key, value))
+            details.append(f'{key}={value}')
     return ' '.join(details)
 
 
@@ -315,7 +313,7 @@ def compute_full_sim(dictinput,verbose=False):
 
     def log(message):
         if isinstance(verbose, str):
-            print("[{}] {}".format(verbose, message), flush=True)
+            print(f"[{verbose}] {message}", flush=True)
         elif verbose:
             print(message, flush=True)
 	
@@ -1367,6 +1365,213 @@ def target_acq(instrument, both_spec, warning):
             'ngroup': rphot['input']['configuration']['detector']['ngroup'], 
             'saturation':rphot['2d']['saturation']}
 
+
+def _table_html(rows):
+    table = pd.DataFrame(rows, columns=['Parameter', 'Value'])
+    table = table.set_index('Parameter')
+    table.index.name = None
+    table = table.to_html()
+    return '<table class="table table-striped"> \n' + table[36:len(table)]
+
+
+def _jwst_instrument_name(instrument):
+    names = {
+        'miri': 'MIRI',
+        'nircam': 'NIRCam',
+        'niriss': 'NIRISS',
+        'nirspec': 'NIRSpec',
+    }
+    return names.get(str(instrument).lower(), instrument)
+
+
+def _jwst_template_name(instrument, mode, aperture, filter_name, paired_filter):
+    instrument = str(instrument).lower()
+    mode = str(mode).lower()
+    aperture = str(aperture).lower()
+    if instrument == 'miri':
+        return 'MIRI Low Resolution Spectroscopy'
+    if instrument == 'nirspec':
+        return 'NIRSpec Bright Object Time Series'
+    if instrument == 'niriss':
+        return 'NIRISS Single Object Slitless Spectroscopy'
+    if instrument == 'nircam':
+        return 'NIRCam Grism Time Series'
+    return mode
+
+
+def _is_nircam_short_wave_filter(filter_name):
+    return str(filter_name).lower().startswith(
+        ('f070w', 'f090w', 'f115w', 'f150w', 'f150w2', 'f200w')
+    )
+
+
+def _nircam_channel_mode(mode, aperture, paired_filter):
+    mode = str(mode).lower()
+    aperture = str(aperture).lower()
+    if mode == 'sw_tsgrism' or 'dhs' in aperture:
+        return 'GRISM'
+    if paired_filter is not None:
+        return 'GRISM'
+    return 'IMAGING'
+
+
+def _display_subarray(subarray):
+    if subarray is None:
+        return None
+    return str(subarray).split(' (')[0].upper()
+
+
+def _nircam_output_channels(subarray):
+    subarray = str(subarray).lower()
+    if 'noutputs=1' in subarray:
+        return 1
+    if subarray.startswith('subgrism'):
+        return 4
+    prefix = subarray.split('_', 1)[0]
+    stripe_marker = prefix.rfind('s')
+    if stripe_marker >= 0:
+        try:
+            return int(prefix[stripe_marker + 1:])
+        except ValueError:
+            pass
+    return None
+
+
+def _upper_or_none(value):
+    if value is None:
+        return 'None'
+    return str(value).upper()
+
+
+def _nircam_pupil_rows(filter_name, paired_filter):
+    short_filter = None
+    long_filter = None
+    if filter_name is not None:
+        if _is_nircam_short_wave_filter(filter_name):
+            short_filter = filter_name
+        else:
+            long_filter = filter_name
+    if paired_filter is not None:
+        if _is_nircam_short_wave_filter(paired_filter):
+            short_filter = paired_filter
+        else:
+            long_filter = paired_filter
+    short_pupil_filter = 'None'
+    long_pupil_filter = 'None'
+    if short_filter is not None:
+        short_pupil_filter = f'GDHS0+{_upper_or_none(short_filter)}'
+    if long_filter is not None:
+        long_pupil_filter = f'GRISMR+{_upper_or_none(long_filter)}'
+    if short_filter is None and long_filter is not None:
+        short_pupil_filter = 'CHOOSE THIS USING ETC'
+    return [
+        ('Short Pupil+Filter', short_pupil_filter),
+        ('Long Pupil+Filter', long_pupil_filter),
+    ]
+
+
+def build_timing_display_div(out, timing):
+    """Build the browser-facing JWST timing tables."""
+    configuration = out['input']['configuration']
+    instrument_config = configuration['instrument']
+    detector_config = configuration['detector']
+
+    instrument = instrument_config.get('instrument')
+    mode = instrument_config.get('mode')
+    aperture = instrument_config.get('aperture')
+    filter_name = instrument_config.get('filter')
+    paired_filter = instrument_config.get('pandexofilterpair')
+    readout_pattern = detector_config.get(
+        'readout_pattern',
+        detector_config.get('readmode')
+    )
+    nstripes = int(timing.get('Num Superstripes', 1) or 1)
+
+    apt_rows = [
+        ('Instrument', _jwst_instrument_name(instrument)),
+        (
+            'Template',
+            _jwst_template_name(
+                instrument, mode, aperture, filter_name, paired_filter
+            )
+        ),
+    ]
+    if str(instrument).lower() == 'nircam':
+        apt_rows.append(
+            ('SW Channel Mode', _nircam_channel_mode(mode, aperture, paired_filter))
+        )
+    apt_rows.append(('Subarray', _display_subarray(detector_config.get('subarray'))))
+    if str(instrument).lower() == 'nircam':
+        apt_rows.append(
+            ('No. of Output Channels', _nircam_output_channels(detector_config.get('subarray')))
+        )
+    apt_rows.append(('Exposures/Dith', 1))
+    if str(instrument).lower() == 'nircam':
+        apt_rows.extend(_nircam_pupil_rows(filter_name, paired_filter))
+    else:
+        apt_rows.append(('Filter', filter_name))
+    apt_rows.extend([
+        ('Readout Pattern', readout_pattern),
+        (
+            'Groups per Integration',
+            timing['APT: Num Groups per Integration']
+        ),
+        (
+            'Integrations per Occultation',
+            timing['APT: Num Integrations per Occultation']
+        ),
+    ])
+
+    calculation_rows = [
+        ('Transit Duration (hr)', timing['Transit Duration']),
+        ('Number of Transits', timing['Number of Transits']),
+        (
+            'Transit + Baseline, No Overhead (hr)',
+            timing['Transit+Baseline, no overhead (hrs)']
+        ),
+        ('Observing Efficiency (%)', timing['Observing Efficiency (%)']),
+        ('Frame Time (sec)', timing['Seconds per Frame']),
+        ('Integrations In Transit', timing['Num Integrations In Transit']),
+        ('Integrations Out of Transit', timing['Num Integrations Out of Transit']),
+    ]
+
+    if nstripes > 1:
+        calculation_rows.extend([
+            ('Number of Stripes', nstripes),
+            (
+                'Elapsed Time per APT Integration incl. Reset (sec)',
+                timing['Time/Integration incl reset (sec)']
+            ),
+            (
+                'Science Time per Full Multistripe Cycle excl. Reset (sec)',
+                timing['Measurement Time per Integration (sec)']
+            ),
+            (
+                'Science Time per Stripe excl. Reset (sec)',
+                timing['Measurement Time per Integration (sec)'] / float(nstripes)
+            ),
+        ])
+    else:
+        calculation_rows.extend([
+            (
+                'Elapsed Time per Integration incl. Reset (sec)',
+                timing['Time/Integration incl reset (sec)']
+            ),
+            (
+                'Science Time per Integration excl. Reset (sec)',
+                timing['Measurement Time per Integration (sec)']
+            ),
+        ])
+
+    timing_div = (
+        '<h3>APT Inputs</h3>\n'
+        + _table_html(apt_rows)
+        + '\n<h3>Calculation Details</h3>\n'
+        + _table_html(calculation_rows)
+    )
+    return timing_div.encode()
+
+
 def as_dict(out, both_spec ,binned, timing, mag, sat_level, warnings, punit, unbinned,calculation): 
     """Format dictionary for output data 
     
@@ -1404,15 +1609,7 @@ def as_dict(out, both_spec ,binned, timing, mag, sat_level, warnings, punit, unb
 
     p=1.0
     if punit == 'fp/f*': p = -1.0
-    frame_loss = timing['Zero Frame Efficiency Loss']
-    timing.pop("Zero Frame Efficiency Loss")
-    timing_div = pd.DataFrame.from_dict(timing, orient='index')
-    #add back in so its not in html, but in timing dict 
-    timing["Zero Frame Efficiency Loss"]=frame_loss
-    timing_div.columns = ['Value']
-    timing_div = timing_div.to_html()
-    timing_div = '<table class="table table-striped"> \n' + timing_div[36:len(timing_div)] 
-    timing_div = timing_div.encode()
+    timing_div = build_timing_display_div(out, timing)
 
     warnings_div = pd.DataFrame.from_dict(warnings, orient='index')
     warnings_div.columns = ['Value']

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -854,12 +854,12 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
 
         if ngroups_per_int > max_ngroup_instrument:
             ngroups_per_int = max_ngroup_instrument
-            flag_high = "Groups/int > max num of allowed groups"
+            flag_high = f"Optimized NGROUPS above maximum ({max_ngroup_instrument}). SET TO NGROUPS={max_ngroup_instrument}"
  
         if (ngroups_per_int < mingroups) | np.isnan(ngroups_per_int):
             ngroups_per_int = mingroups
             nframes_per_int = mingroups
-            flag_default = "NGROUPS<"+str(mingroups)+"SET TO NGROUPS="+str(mingroups)
+            flag_default = f"Optimized NGROUPS below minimum ({mingroups}). SET TO NGROUPS={mingroups}"
 
     elif 'ngroups_per_int' in locals(): 
         #if it maxexptime_per_int been defined then set nframes per int 
@@ -871,7 +871,7 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
         #for the sake of not returning error
         ngroups_per_int = mingroups
         nframes_per_int = mingroups
-        flag_default = "Something went wrong. SET TO NGROUPS="+str(mingroups)
+        flag_default = f"Something went wrong. SET TO NGROUPS={mingroups}"
 
     if ngroups_per_int == 1: 
         frame_zero_dead = 0 

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -805,22 +805,21 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
     if nsuperstripe < 1:
         nsuperstripe = 1
     def _clocktime_per_int(ngroups):
-        if nsuperstripe > 1:
-            if (m.get("exposure_time_per_int") is not None and
-                    ngroups == m.get("exposure_time_ngroup")):
-                return m["exposure_time_per_int"]/float(nsuperstripe)
-            if m.get("tfffr") is not None:
-                full_cycle = nsuperstripe * (
-                    m["tfffr"]
-                    + tframe * (
-                        m.get("nreset1", 1)
-                        + m.get("ndrop1", 0)
-                        + (ngroups - 1.0)*(nframe + nskip)
-                        + nframe
-                        + m.get("ndrop3", 0)
-                    )
+        if (m.get("exposure_time_per_int") is not None and
+                ngroups == m.get("exposure_time_ngroup")):
+            return m["exposure_time_per_int"]
+        if nsuperstripe > 1 and m.get("tfffr") is not None:
+            full_cycle = nsuperstripe * (
+                m["tfffr"]
+                + tframe * (
+                    m.get("nreset1", 1)
+                    + m.get("ndrop1", 0)
+                    + (ngroups - 1.0)*(nframe + nskip)
+                    + nframe
+                    + m.get("ndrop3", 0)
                 )
-                return full_cycle/float(nsuperstripe)
+            )
+            return full_cycle
         return (ngroups+1.0)*tframe
     overhead_per_int = tframe #overhead time added per integration 
     try: 
@@ -887,18 +886,17 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
     #group 
     exptime_per_int = ngroups_per_int*tframe
     
-    #clock time includes the reset frame. For SOSS multistripe Pandeia's
-    #exposure_time is a full superstripe cycle, while PandExo keeps the
-    #historical integration count on a single-superstripe scale and divides
-    #by nsuperstripe for per-wavelength noise scaling.
+    # Clock time includes reset/readout overheads. For multistripe readouts,
+    # Pandeia's exposure_time is the full APT integration cycle across all
+    # stripes; per-wavelength noise scaling is handled by the effective
+    # integration counts below.
     clocktime_per_int = _clocktime_per_int(ngroups_per_int)
     
     #observing efficiency (i.e. what percentage of total time is spent on soure)
     eff = (ngroups_per_int + frame_zero_dead)/(ngroups_per_int + 1.0)
     
-    # this says "per occultation" but this is just the in-transit integration
-    # slots. For SOSS multistripe the clock is one superstripe slice of the
-    # full Pandeia exposure cycle.
+    # This says "per occultation" but this is just the in-transit integration
+    # count. For multistripe modes the clock is the full APT integration cycle.
     nint_per_occultation =  transit_duration/clocktime_per_int
     
     #figure out how many integrations are in transit and how many are out of transit 

--- a/pandexo/engine/reference/miri_input.json
+++ b/pandexo/engine/reference/miri_input.json
@@ -66,7 +66,7 @@
             "method": "specapphot",
             "background_subtraction":true,
             "aperture_size": 0.6,
-            "sky_annulus": [2.3,3.0],
+            "sky_annulus": [1.0,2.8],
             "target_xy": [0.0, 0.0],
             "reference_wavelength": null,
             "units":"arcsec"

--- a/pandexo/engine/reference/nircam_dhs_input.json
+++ b/pandexo/engine/reference/nircam_dhs_input.json
@@ -63,8 +63,8 @@
     "strategy": {
             "method": "specapphot",
             "background_subtraction":true,
-            "aperture_size": 0.7,
-            "sky_annulus": [0.8,1.6],
+            "aperture_size": 0.4,
+            "sky_annulus": [0.5,1.5],
             "target_xy": [0.0, 0.0],
             "reference_wavelength":null,
             "units":"arcsec"

--- a/pandexo/engine/reference/nircam_input.json
+++ b/pandexo/engine/reference/nircam_input.json
@@ -63,8 +63,8 @@
     "strategy": {
             "method": "specapphot",
             "background_subtraction":true,
-            "aperture_size": 0.7,
-            "sky_annulus": [0.8,1.6],
+            "aperture_size": 0.4,
+            "sky_annulus": [0.5,1.5],
             "target_xy": [0.0, 0.0],
             "reference_wavelength":null,
             "units":"arcsec"

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -629,8 +629,7 @@
 	      $("#ptempc").attr("required", false);
       });
 
-        /* Instrument Selection */
-        $("#instrument").change(function () {
+        function showSelectedInstrumentMode() {
             $("#instrument-mode-section").removeClass("hidden");
             $("#MIRI, #NIRSpec, #NIRISS, #NIRCam, #NIRCamDHS").addClass("hidden");
             var selopt = $("#instrument").val();
@@ -651,7 +650,10 @@
                     $("#NIRCamDHS").removeClass("hidden");
                     break;
             }
-        });
+        }
+
+        /* Instrument Selection */
+        $("#instrument").change(showSelectedInstrumentMode);
 
       //if we're editing, set the form values to what it was before
       var obj = JSON.parse($("#formDataJson").val());
@@ -662,13 +664,23 @@
 	      if (radioNames.includes(name)) {
 		  $(`input[name='${name}'][value='${value}']`).trigger("click");
 	      }
-	      else if (dropdownNames.includes(name)) {
-		  $(`select[name='${name}']`).val(value).trigger("change");
-	      }
 	      else {
 		  $("#" + name).val(value);
 	      }
 	  });
+
+          if (obj.instrument) {
+              $("#instrument").val(obj.instrument).trigger("change.select2");
+              showSelectedInstrumentMode();
+          }
+
+	  $.each(obj, function(name, value) {
+	      if (dropdownNames.includes(name) && name != "instrument") {
+		  $(`select[name='${name}']`).val(value).trigger("change.select2");
+	      }
+	  });
+
+          show_dropdown();
       }
       else {
 	  //default radio options
@@ -689,6 +701,9 @@
                 $("#phoenix").removeClass("hidden");
                 break;
         }
+    }
+
+    function showForm() {
     }
 
 

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -562,6 +562,13 @@
             minimumResultsForSearch: 7
         });
 
+        $("#instrument-mode-section").on("select2:select", "select", function () {
+            var select = $(this);
+            window.setTimeout(function () {
+                select.select2("close");
+            }, 0);
+        });
+
         /* Nice block level radio selection */
         $(".radio-chooser-content").click(function () {
             $(".radio-chooser-item").removeClass("radio-chooser-selected");

--- a/pandexo/engine/utils/plot_helpers.py
+++ b/pandexo/engine/utils/plot_helpers.py
@@ -1,0 +1,82 @@
+import numpy as np
+
+
+def add_wavelength_gap_breaks(x, y, gap_factor=5.0):
+    """Insert visual line breaks at large gaps in a wavelength grid.
+
+    Bokeh line and step glyphs draw a continuous segment between adjacent
+    finite points. For NIRSpec spectra, the valid NRS1 and NRS2 samples can be
+    adjacent in the plotted arrays even though a detector gap separates them on
+    the wavelength axis. This helper inserts an extra point with a finite
+    midpoint wavelength and a NaN ordinate after any isolated, unusually large
+    positive wavelength step, causing Bokeh to break the rendered line at that
+    location.
+
+    The input arrays are otherwise left unchanged. This function is intended
+    for plotting only; the returned arrays should not be reused for numerical
+    calculations or binning.
+
+    Parameters
+    ----------
+    x : array-like
+        Wavelength coordinates, expected to be ordered monotonically for normal
+        spectral plots. Non-finite values are ignored when estimating local
+        wavelength spacings.
+    y : array-like
+        Values to plot at each wavelength. Must have the same shape as ``x``.
+    gap_factor : float, optional
+        Dimensionless multiplier on the local wavelength spacing, not a value
+        in microns. A positive wavelength step larger than ``gap_factor`` times
+        the median of nearby positive finite wavelength steps is treated as a
+        plotting gap. For example, if the neighboring spacings are about 0.01
+        microns, the default value of 5.0 breaks the plotted line at jumps
+        larger than about 0.05 microns. Because the reference spacing is local,
+        smooth dispersion changes across an instrument mode should not be
+        treated as gaps.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        The possibly expanded ``(x, y)`` arrays. If no gap is detected, or the
+        inputs are too short or shape-incompatible, the arrays are returned
+        after conversion to floating point NumPy arrays.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+
+    if x.size < 3 or y.shape != x.shape:
+        return x, y
+
+    steps = np.diff(x)
+    if not np.any(np.isfinite(steps) & (steps > 0.0)):
+        return x, y
+
+    def local_typical_step(step_index, radius=3):
+        start = max(0, step_index - radius)
+        stop = min(steps.size, step_index + radius + 1)
+        local_steps = np.delete(steps[start:stop], step_index - start)
+        local_steps = local_steps[np.isfinite(local_steps) & (local_steps > 0.0)]
+        if local_steps.size == 0:
+            return np.nan
+        return np.median(local_steps)
+
+    xout = []
+    yout = []
+    for i, (xi, yi) in enumerate(zip(x, y)):
+        xout.append(xi)
+        yout.append(yi)
+        if i == x.size - 1:
+            continue
+        step = steps[i]
+        typical_step = local_typical_step(i)
+        if (
+            np.isfinite(step)
+            and step > 0.0
+            and np.isfinite(typical_step)
+            and typical_step > 0.0
+            and step > gap_factor * typical_step
+        ):
+            xout.append(0.5 * (xi + x[i + 1]))
+            yout.append(np.nan)
+
+    return np.asarray(xout), np.asarray(yout)

--- a/pandexo/engine/utils/plotters.py
+++ b/pandexo/engine/utils/plotters.py
@@ -10,6 +10,7 @@ from bokeh.models import  ColumnDataSource, Slider,Select
 from bokeh.models.callbacks import CustomJS
 from bokeh.io import curdoc
 from bokeh.layouts import row
+from .plot_helpers import add_wavelength_gap_breaks
 
 def create_component_jwst(result_dict):
     """Generate front end plots JWST
@@ -219,6 +220,8 @@ def create_component_jwst(result_dict):
     #x = x[~np.isnan(y)]
     #y = y[~np.isnan(y)]
     x,y = raw['wave'],raw['electron_per_int']
+    if x_axis_label.startswith('Wavelength'):
+        x, y = add_wavelength_gap_breaks(x, y)
 
     plot_flux_1d1 = Figure(tools=TOOLS,
                          x_axis_label='Wavelength [microns]',
@@ -240,6 +243,8 @@ def create_component_jwst(result_dict):
 
     # SNR 
     x,y = raw['snr_int'][0],raw['snr_int'][1] #this is computing the SNR (sqrt of photons in a single integration)
+    if x_axis_label.startswith('Wavelength'):
+        x, y = add_wavelength_gap_breaks(x, y)
 
 
     plot_snr_1d1 = Figure(tools=TOOLS,
@@ -256,8 +261,14 @@ def create_component_jwst(result_dict):
     x = x[~np.isnan(y)]
     y = y[~np.isnan(y)]    
     ymed = np.median(y)
+    x_plot, y_plot = (
+        add_wavelength_gap_breaks(x, y)
+        if x_axis_label.startswith('Wavelength')
+        else (x, y)
+    )
+    nocc_plot = x_plot*0+noccultations
 
-    source2 = ColumnDataSource(data=dict(x=x, y=y,nocc=x*0+noccultations))
+    source2 = ColumnDataSource(data=dict(x=x_plot, y=y_plot,nocc=nocc_plot))
     original2 = ColumnDataSource(data=dict(x=x, y=y,nocc=x*0+noccultations))
 
     plot_noise_1d1 = Figure(tools=TOOLS,#responsive=True,
@@ -314,6 +325,61 @@ def create_component_jwst(result_dict):
             function add(a, b) {
                 return a+b;
             }
+            function addGaps(xin, yin) {
+                if (xin.length < 3) {
+                    return [xin.slice(0), yin.slice(0)];
+                }
+
+                var steps = [];
+                for (var j = 0; j < xin.length-1; j++) {
+                    steps.push(xin[j+1] - xin[j]);
+                }
+                function median(values) {
+                    values.sort(function(a, b) { return a-b; });
+                    var middle = Math.floor(values.length/2);
+                    if (values.length % 2 == 1) {
+                        return values[middle];
+                    }
+                    return 0.5*(values[middle-1] + values[middle]);
+                }
+                function localTypicalStep(index) {
+                    var radius = 3;
+                    var start = Math.max(0, index-radius);
+                    var stop = Math.min(steps.length, index+radius+1);
+                    var local = [];
+                    for (var k = start; k < stop; k++) {
+                        if (k != index && isFinite(steps[k]) && steps[k] > 0) {
+                            local.push(steps[k]);
+                        }
+                    }
+                    if (local.length == 0) {
+                        return NaN;
+                    }
+                    return median(local);
+                }
+
+                var xgap = [];
+                var ygap = [];
+                for (var j = 0; j < xin.length; j++) {
+                    xgap.push(xin[j]);
+                    ygap.push(yin[j]);
+                    if (j < xin.length-1) {
+                        var step = steps[j];
+                        var typical = localTypicalStep(j);
+                        if (
+                            isFinite(step)
+                            && step > 0
+                            && isFinite(typical)
+                            && typical > 0
+                            && step > 5.0*typical
+                        ) {
+                            xgap.push(0.5*(xin[j] + xin[j+1]));
+                            ygap.push(NaN);
+                        }
+                    }
+                }
+                return [xgap, ygap];
+            }
             for (i = 0; i < ind.length-1; i++) {
 
                 xslice = x.slice(ind[i],ind[i+1]);
@@ -327,11 +393,15 @@ def create_component_jwst(result_dict):
             }
             
             var new_err = 1.0;
-            for (i = 0; i < x.length; i++) {
+            var yscaled = [];
+            for (i = 0; i < yout.length; i++) {
                 new_err = yout[i]*Math.sqrt(og_ntran[i]/ntran);
-                x[i] = xout[i];
-                y[i] = new_err       
+                yscaled.push(new_err);
             }
+            var gapped = addGaps(xout, yscaled);
+            sdata['x'] = gapped[0];
+            sdata['y'] = gapped[1];
+            sdata['nocc'] = new Array(gapped[0].length).fill(ntran);
 
             source.change.emit();
         """)    

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -242,6 +242,18 @@ def test_multistripe_effective_time_is_divided_by_nsuperstripe():
     )
 
 
+def test_slope_method_reports_per_stripe_electrons_per_real_integration():
+    result = _slope_result(_timing(nsuperstripe=4))
+
+    assert result["photon_out_1d_per_int"] == pytest.approx([250.0, 250.0])
+
+
+def test_fml_method_reports_electrons_per_real_integration():
+    result = _fml_result(_timing(nsuperstripe=1))
+
+    assert result["photon_out_1d_per_int"] == pytest.approx([1000.0, 1000.0])
+
+
 def test_pandeia_measurement_time_update_controls_on_source_metadata():
     timing = _timing(nsuperstripe=4)
     update_timing_measurement_time(timing, measurement_time_per_int=32.0)

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -254,18 +254,67 @@ def test_pandeia_measurement_time_update_controls_on_source_metadata():
     )
 
 
-def test_multistripe_timing_uses_pandeia_full_cycle_clock_without_double_counting():
+def test_multistripe_timing_uses_pandeia_full_cycle_clock_for_real_integrations():
     timing = _timing_with_pandeia_cycle(
         nsuperstripe=4,
         exposure_time_per_int=40.0,
         ngroup=3,
     )
 
-    assert timing["Time/Integration incl reset (sec)"] == pytest.approx(10.0)
-    assert timing["Num Integrations In Transit"] == 5
-    assert timing["Effective Integrations In Transit"] == pytest.approx(1.25)
+    assert timing["Time/Integration incl reset (sec)"] == pytest.approx(40.0)
+    assert timing["Num Integrations In Transit"] == 2
+    assert timing["Effective Integrations In Transit"] == pytest.approx(0.5)
     assert timing["Measurement Time per Integration (sec)"] == pytest.approx(16.0)
-    assert timing["On Source Time In Transit"] == pytest.approx(20.0)
+    assert timing["On Source Time In Transit"] == pytest.approx(8.0)
+
+
+def test_dhs_clock_time_includes_pandeia_fixed_overhead():
+    timing, _ = compute_timing(
+        {
+            "ngroup": 30,
+            "tframe": 1.36765,
+            "nframe": 1,
+            "mingroups": 2,
+            "nskip": 0,
+            "nsuperstripe": 1,
+            "exposure_time_per_int": 42.41763,
+            "exposure_time_ngroup": 30,
+        },
+        transit_duration=2.8032 * 3600.0,
+        expfact_out=1.0,
+        noccultations=1,
+        max_ngroup_instrument=101,
+    )
+
+    assert timing["Time/Integration incl reset (sec)"] == pytest.approx(42.41763)
+    assert timing["Measurement Time per Integration (sec)"] == pytest.approx(39.66185)
+
+
+def test_soss_sub17stripe_clock_time_matches_pandeia_full_cycle():
+    timing, _ = compute_timing(
+        {
+            "ngroup": 8,
+            "tframe": 0.06164,
+            "nframe": 1,
+            "mingroups": 2,
+            "nskip": 0,
+            "nsuperstripe": 120,
+            "exposure_time_per_int": 69.0288,
+            "exposure_time_ngroup": 8,
+        },
+        transit_duration=2.8032 * 3600.0,
+        expfact_out=1.0,
+        noccultations=1,
+        max_ngroup_instrument=65536,
+    )
+
+    assert timing["Time/Integration incl reset (sec)"] == pytest.approx(69.0288)
+    assert timing["Measurement Time per Integration (sec)"] == pytest.approx(51.7776)
+    assert timing["Measurement Time per Integration (sec)"] / timing[
+        "Num Superstripes"
+    ] == pytest.approx(0.43148)
+    assert timing["Num Integrations In Transit"] == 147
+    assert timing["Effective Integrations In Transit"] == pytest.approx(147 / 120.0)
 
 
 def test_multistripe_timing_display_uses_apt_and_calculation_tables():

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -189,7 +189,7 @@ def test_compute_timing_keeps_single_group_on_source_time_positive():
         * timing["Num Integrations In Transit"]
         > 0
     )
-    assert flags["flag_default"] == "NGROUPS<1SET TO NGROUPS=1"
+    assert flags["flag_default"] == "Optimized NGROUPS below minimum (1). SET TO NGROUPS=1"
 
 
 def test_multigroup_measurement_time_preserves_first_minus_last_interval():

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -10,6 +10,7 @@ import pytest
 
 from pandexo.engine.compute_noise import ExtractSpec
 from pandexo.engine.jwst import (
+    build_timing_display_div,
     compute_timing,
     select_calculation,
     update_timing_measurement_time,
@@ -52,6 +53,26 @@ def _timing_with_pandeia_cycle(nsuperstripe, exposure_time_per_int, ngroup=3):
         max_ngroup_instrument=65536,
     )
     return timing
+
+
+def _pandeia_out(instrument=None, detector=None):
+    return {
+        "input": {
+            "configuration": {
+                "instrument": instrument or {
+                    "instrument": "niriss",
+                    "mode": "soss",
+                    "filter": "clear",
+                    "aperture": "soss",
+                    "disperser": "gr700xd",
+                },
+                "detector": detector or {
+                    "subarray": "substrip96",
+                    "readout_pattern": "nisrapid",
+                },
+            }
+        }
+    }
 
 
 def _fml_result(timing):
@@ -245,6 +266,99 @@ def test_multistripe_timing_uses_pandeia_full_cycle_clock_without_double_countin
     assert timing["Effective Integrations In Transit"] == pytest.approx(1.25)
     assert timing["Measurement Time per Integration (sec)"] == pytest.approx(16.0)
     assert timing["On Source Time In Transit"] == pytest.approx(20.0)
+
+
+def test_multistripe_timing_display_uses_apt_and_calculation_tables():
+    timing = _timing_with_pandeia_cycle(
+        nsuperstripe=4,
+        exposure_time_per_int=40.0,
+        ngroup=3,
+    )
+    html = build_timing_display_div(_pandeia_out(), timing).decode()
+
+    assert "APT Inputs" in html
+    assert "Calculation Details" in html
+    assert "Groups per Integration" in html
+    assert "Integrations per Occultation" in html
+    assert "Number of Stripes" in html
+    assert "Elapsed Time per APT Integration incl. Reset (sec)" in html
+    assert "Science Time per Full Multistripe Cycle excl. Reset (sec)" in html
+    assert "Science Time per Stripe excl. Reset (sec)" in html
+    assert "Effective Per-Wavelength" not in html
+    assert "Time/Integration incl reset" not in html
+    assert "Measurement Time per Integration" not in html
+
+
+def test_non_multistripe_timing_display_omits_stripe_rows():
+    timing = _timing(nsuperstripe=1)
+    html = build_timing_display_div(_pandeia_out(), timing).decode()
+
+    assert "Elapsed Time per Integration incl. Reset (sec)" in html
+    assert "Science Time per Integration excl. Reset (sec)" in html
+    assert "Number of Stripes" not in html
+    assert "Full Multistripe Cycle" not in html
+    assert "Science Time per Stripe" not in html
+
+
+def test_nircam_timing_display_shows_channel_and_pupil_rows():
+    timing = _timing(nsuperstripe=1)
+    html = build_timing_display_div(
+        _pandeia_out(
+            instrument={
+                "instrument": "nircam",
+                "mode": "sw_tsgrism",
+                "filter": "f150w2",
+                "pandexofilterpair": "f322w2",
+                "aperture": "dhs0spec8",
+                "disperser": "dhs0",
+            },
+            detector={
+                "subarray": "sub260s4_8-spectra",
+                "readout_pattern": "rapid",
+            },
+        ),
+        timing,
+    ).decode()
+
+    assert "SW Channel Mode" in html
+    assert "GRISM" in html
+    assert "SUB260S4_8-SPECTRA" in html
+    assert "No. of Output Channels" in html
+    assert "<td>4</td>" in html
+    assert "Short Pupil+Filter" in html
+    assert "GDHS0+F150W2" in html
+    assert "Long Pupil+Filter" in html
+    assert "GRISMR+F322W2" in html
+
+
+def test_nircam_lw_only_timing_display_shows_imaging_sw_channel():
+    timing = _timing(nsuperstripe=1)
+    html = build_timing_display_div(
+        _pandeia_out(
+            instrument={
+                "instrument": "nircam",
+                "mode": "lw_tsgrism",
+                "filter": "f322w2",
+                "aperture": "lw",
+                "disperser": "grismr",
+            },
+            detector={
+                "subarray": "subgrism64",
+                "readout_pattern": "rapid",
+            },
+        ),
+        timing,
+    ).decode()
+
+    assert "SW Channel Mode" in html
+    assert "IMAGING" in html
+    assert "SUBGRISM64" in html
+    assert "No. of Output Channels" in html
+    assert "<td>4</td>" in html
+    assert "Short Pupil+Filter" in html
+    assert "CHOOSE THIS USING ETC" in html
+    assert "Long Pupil+Filter" in html
+    assert "GRISMR+F322W2" in html
 
 
 def test_slope_uncertainty_increases_by_sqrt_nsuperstripe():

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -10,6 +10,7 @@ import pytest
 
 from pandexo.engine.compute_noise import ExtractSpec
 from pandexo.engine.jwst import (
+    add_warnings,
     build_timing_display_div,
     compute_timing,
     select_calculation,
@@ -315,6 +316,84 @@ def test_soss_sub17stripe_clock_time_matches_pandeia_full_cycle():
     ] == pytest.approx(0.43148)
     assert timing["Num Integrations In Transit"] == 147
     assert timing["Effective Integrations In Transit"] == pytest.approx(147 / 120.0)
+
+
+def test_soss_multistripe_efficiency_uses_per_stripe_science_time():
+    timing, _ = compute_timing(
+        {
+            "ngroup": 1111,
+            "tframe": 0.06164,
+            "nframe": 1,
+            "mingroups": 2,
+            "nskip": 0,
+            "nsuperstripe": 120,
+            "exposure_time_per_int": 8227.6992,
+            "exposure_time_ngroup": 1111,
+        },
+        transit_duration=2.8032 * 3600.0,
+        expfact_out=1.0,
+        noccultations=1,
+        max_ngroup_instrument=65536,
+    )
+
+    assert timing["Observing Efficiency (%)"] == pytest.approx(0.8315860648)
+
+
+def test_optimized_multistripe_timing_reduces_ngroups_for_minimum_integrations():
+    timing, flags = compute_timing(
+        {
+            "maxexptime_per_int": 1109 * 0.06164,
+            "tframe": 0.06164,
+            "nframe": 1,
+            "mingroups": 2,
+            "nskip": 0,
+            "nsuperstripe": 120,
+            "tfffr": 0.02048,
+            "nreset1": 1,
+            "ndrop1": 0,
+            "ndrop3": 0,
+        },
+        transit_duration=2.8032 * 3600.0,
+        expfact_out=1.0,
+        noccultations=1,
+        max_ngroup_instrument=65536,
+    )
+
+    assert timing["APT: Num Groups per Integration"] == 369
+    assert timing["Num Integrations In Transit"] >= 3
+    assert "Reduced NGROUPS from 1109 to 369" in flags["flag_min_nint"]
+
+
+def test_user_multistripe_timing_warns_without_changing_ngroups_below_minimum():
+    timing, flags = compute_timing(
+        {
+            "ngroup": 1111,
+            "tframe": 0.06164,
+            "nframe": 1,
+            "mingroups": 2,
+            "nskip": 0,
+            "nsuperstripe": 120,
+            "exposure_time_per_int": 8227.6992,
+            "exposure_time_ngroup": 1111,
+        },
+        transit_duration=2.8032 * 3600.0,
+        expfact_out=1.0,
+        noccultations=1,
+        max_ngroup_instrument=65536,
+    )
+
+    warnings = add_warnings(
+        {"warnings": {}},
+        timing,
+        sat_level=0.8,
+        flags=flags,
+        instrument="niriss",
+    )
+
+    assert timing["APT: Num Groups per Integration"] == 1111
+    assert timing["Num Integrations In Transit"] == 2
+    assert "User-specified NGROUPS produces 2" in flags["flag_min_nint"]
+    assert warnings["Minimum Integrations?"] == flags["flag_min_nint"]
 
 
 def test_multistripe_timing_display_uses_apt_and_calculation_tables():

--- a/tests/test_nirspec_valid_channels.py
+++ b/tests/test_nirspec_valid_channels.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from pandexo.engine.jwst import nirspec_valid_channel_mask
+from pandexo.engine.jwst import (
+    dhs_f150w_wavelength_mask,
+    nirspec_valid_channel_mask,
+)
 
 
 def test_nirspec_mask_rejects_unobserved_channels():
@@ -47,3 +50,53 @@ def test_nirspec_mask_is_only_for_nirspec(instrument, disperser):
     }
 
     assert nirspec_valid_channel_mask(conf, np.array([1.0, 0.0])) is None
+
+
+def test_dhs_f150w_mask_truncates_below_minimum_wavelength():
+    conf = {
+        "instrument": {
+            "instrument": "nircam",
+            "mode": "dhs",
+            "aperture": "dhs0spec8",
+            "filter": "f150w2",
+        }
+    }
+
+    mask = dhs_f150w_wavelength_mask(
+        conf, np.array([0.94, 0.96, 1.0, 1.5])
+    )
+
+    assert mask.tolist() == [False, True, True, True]
+
+
+@pytest.mark.parametrize(
+    "conf",
+    [
+        {
+            "instrument": {
+                "instrument": "nircam",
+                "mode": "lw_tsgrism",
+                "aperture": "lw",
+                "filter": "f322w2",
+            }
+        },
+        {
+            "instrument": {
+                "instrument": "nircam",
+                "mode": "ssgrism",
+                "aperture": "lw",
+                "filter": "f150w2",
+            }
+        },
+        {
+            "instrument": {
+                "instrument": "nirspec",
+                "mode": "fixed_slit",
+                "aperture": "s1600a1",
+                "filter": "f100lp",
+            }
+        },
+    ],
+)
+def test_dhs_f150w_mask_only_applies_to_dhs_f150w(conf):
+    assert dhs_f150w_wavelength_mask(conf, np.array([0.94, 1.0])) is None

--- a/tests/test_plot_helpers.py
+++ b/tests/test_plot_helpers.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from pandexo.engine.utils.plot_helpers import add_wavelength_gap_breaks
+
+
+def test_add_wavelength_gap_breaks_inserts_nan_after_large_jump():
+    x, y = add_wavelength_gap_breaks(
+        np.array([3.70, 3.71, 3.72, 3.84, 3.85]),
+        np.array([10.0, 11.0, 12.0, 20.0, 21.0]),
+    )
+
+    assert np.isnan(y[3])
+    assert x[3] == pytest.approx(3.78)
+    np.testing.assert_allclose(x, [3.70, 3.71, 3.72, 3.78, 3.84, 3.85])
+
+
+def test_add_wavelength_gap_breaks_leaves_regular_grid_unchanged():
+    x = np.array([3.70, 3.71, 3.72, 3.73])
+    y = np.array([10.0, 11.0, 12.0, 13.0])
+
+    xout, yout = add_wavelength_gap_breaks(x, y)
+
+    np.testing.assert_array_equal(xout, x)
+    np.testing.assert_array_equal(yout, y)
+
+
+def test_add_wavelength_gap_breaks_allows_smooth_dispersion_change():
+    steps = np.array([
+        0.010,
+        0.011,
+        0.013,
+        0.017,
+        0.025,
+        0.040,
+        0.055,
+        0.070,
+        0.085,
+    ])
+    x = np.concatenate(([5.0], 5.0 + np.cumsum(steps)))
+    y = np.arange(x.size, dtype=float)
+
+    xout, yout = add_wavelength_gap_breaks(x, y)
+
+    np.testing.assert_array_equal(xout, x)
+    np.testing.assert_array_equal(yout, y)


### PR DESCRIPTION
## Summary

This PR improves several JWST calculation, timing, plotting, and browser-interface behaviors, with particular attention to NIRCam/DHS and NIRISS/SOSS multistripe observations.

## Changes

### Spectral plotting

* Break plotted spectral lines across real wavelength gaps, including the NIRSpec NRS1/NRS2 detector gap.

  * Gap detection uses changes in the local wavelength spacing so that smoothly varying dispersion, such as MIRI/LRS, is not incorrectly split.
* Trim low-throughput NIRCam DHS F150W2 wavelengths below 0.96 microns to avoid misleading/ugly plot tails.
* Fix `Flux per Int` plots for multistripe modes, whose noise calculations use the slope method rather than the standard first-minus-last products.

  * Explicitly calculate and return per-integration extracted fluxes for both slope-method and first-minus-last calculations.

### JWST timing calculations

* Match elapsed JWST integration timing to Pandeia/ETC `exposure_time`, including fixed readout overheads such as `tfffr`.
* Treat the reported SOSS/DHS multistripe exposure time as the full APT integration cycle.
* Keep elapsed integration time, full-cycle science time, and per-stripe science time as separate quantities.
* Preserve integration counts as actual APT integrations rather than dividing them by the number of stripes (a recently introduced bug).
* Calculate multistripe observing efficiency using the per-stripe science time (which properly reflects the poor efficiency of multi-stripe modes).
* Require optimized calculations to provide at least three in-transit integrations when possible by reducing `NGROUPS` (raising a warning when doing so).

  * User-specified `NGROUPS` values are preserved. A warning is shown when a user-selected configuration produces fewer than three in-transit integrations.
* Update JWST `max_ngroup` limits and clarify related warning messages.

### Browser timing output

* Reorganize the JWST **Timing Info** output into separate **APT Inputs** and **Calculation Details** tables.
* Add clearer labels for:

  * elapsed APT integration time;
  * full-cycle science time;
  * per-stripe science time; and
  * multistripe observing efficiency.
* Add NIRCam-specific rows for:

  * SW channel mode;
  * number of output channels;
  * short-wavelength pupil and filter; and
  * long-wavelength pupil and filter.

### Browser form behavior and defaults

* Fix restoration of JWST instrument and mode settings when editing an already-run calculation.
* Close Select2 mode dropdowns consistently after a selection is made.
* Adjust MIRI and NIRCam aperture and sky-annulus defaults to more representative values based on ETC experiments.

## Testing

Adds focused regression coverage for:

* wavelength-gap detection and plotting;
* NIRCam DHS F150W/F150W2 wavelength trimming;
* standard and multistripe timing-table labels;
* NIRCam-specific APT input rows;
* elapsed DHS and SOSS timing against Pandeia/ETC values;
* multistripe observing efficiency;
* optimized and user-specified `NGROUPS` behavior;
* minimum in-transit integration warnings; and
* related JWST timing and plotting behavior.
