### PR TITLE
Add new MIRI LRS subarrays and NIRSpec PRISM multistripe support

### DIFF
--- a/pandexo/engine/justdoit.py
+++ b/pandexo/engine/justdoit.py
@@ -219,6 +219,8 @@ def load_mode_dict(inst):
     -------
     >>> inst_dict = load_mode_dict('MIRI LRS')
     >>> inst_dict['configuration']['instrument']['aperture'] = 'lrsslit'
+    >>> inst_dict['configuration']['instrument']['mode'] = 'lrsslit'
+    >>> inst_dict['configuration']['detector']['subarray'] = 'subslit'
     """
     return SetDefaultModes(inst).pick()
 
@@ -510,9 +512,11 @@ def subarrays(inst):
             "sub680stripe_soss": 1.83848
             }
   elif inst.lower() == 'nirspec':
-    return {'sub1024a':0.451,'sub1024b':0.451,'sub2048':0.90156,'sub512':0.22572,'sub512s':0.14392}
+    return {'sub1024a':0.451,'sub1024b':0.451,'sub2048':0.90156,'sub512':0.22572,'sub512s':0.14392,
+            's256m2_prm':0.11352,'s128m4_prm':0.0572,'s64m8_prm':0.02904,'s32m16_prm':0.01496}
   elif inst.lower() == 'miri':
-    return {'slitlessprism':0.159}
+    return {'slitlessprism_ip':0.15616,'slitlessprism_ips':0.11776,
+            'slitlessprism':0.15904,'full':2.77504,'subslit':0.27904}
   elif inst.lower()  == 'nircam':
     return {"subgrism64":0.34, "subgrism128":0.67, "subgrism256":1.34,
       "subgrism64 (noutputs=1)":1.3, "subgrism128 (noutputs=1)":2.6, "subgrism256 (noutputs=1)":5.2}

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -1605,10 +1605,18 @@ def build_timing_display_div(out, timing):
     apt_rows.append(('Exposures/Dith', 1))
     if str(instrument).lower() == 'nircam':
         apt_rows.extend(_nircam_pupil_rows(filter_name, paired_filter))
-    else:
+    elif not (
+        str(instrument).lower() == 'miri'
+        and str(mode).lower() in ('lrsslitless', 'lrsslit')
+    ):
         apt_rows.append(('Filter', filter_name))
+    if (
+        str(instrument).lower() == 'miri'
+        and str(mode).lower() in ('lrsslitless', 'lrsslit')
+    ):
+        apt_rows.append(('Dither', 'None'))
     apt_rows.extend([
-        ('Readout Pattern', readout_pattern),
+        ('Readout Pattern', _upper_or_none(readout_pattern)),
         (
             'Groups per Integration',
             timing['APT: Num Groups per Integration']

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -1475,7 +1475,7 @@ def _table_html(rows):
     table = table.set_index('Parameter')
     table.index.name = None
     table = table.to_html(formatters={'Value': format_value})
-    return '<table class="table table-striped"> \n' + table[36:len(table)]
+    return '<table class="table table-striped pandexo-summary-table"> \n' + table[36:len(table)]
 
 
 def _jwst_instrument_name(instrument):
@@ -1741,7 +1741,10 @@ def as_dict(out, both_spec ,binned, timing, mag, sat_level, warnings, punit, unb
     warnings_div = pd.DataFrame.from_dict(warnings, orient='index')
     warnings_div.columns = ['Value']
     warnings_div = warnings_div.to_html()
-    warnings_div = '<table class="table table-striped"> \n' + warnings_div[36:len(warnings_div)]
+    warnings_div = (
+        '<table class="table table-striped pandexo-summary-table"> \n'
+        + warnings_div[36:len(warnings_div)]
+    )
     warnings_div = warnings_div.encode()
     
     map_dhs_names = {'sub40stripe1_dhs':'SUB40S1_2-SPECTRA',
@@ -1770,7 +1773,10 @@ def as_dict(out, both_spec ,binned, timing, mag, sat_level, warnings, punit, unb
     input_div = pd.DataFrame.from_dict(input_dict, orient='index')
     input_div.columns = ['Value']
     input_div = input_div.to_html()
-    input_div = '<table class="table table-striped"> \n' + input_div[36:len(input_div)]
+    input_div = (
+        '<table class="table table-striped pandexo-summary-table"> \n'
+        + input_div[36:len(input_div)]
+    )
     input_div = input_div.encode()
     
     #add calc type to input dict (doing it here so it doesn't output on webpage

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -1464,10 +1464,17 @@ def target_acq(instrument, both_spec, warning):
 
 
 def _table_html(rows):
+    def format_value(value):
+        if isinstance(value, (float, np.floating)):
+            if np.isfinite(value) and float(value).is_integer():
+                return str(int(value))
+            return f'{value:.6f}'
+        return str(value)
+
     table = pd.DataFrame(rows, columns=['Parameter', 'Value'])
     table = table.set_index('Parameter')
     table.index.name = None
-    table = table.to_html()
+    table = table.to_html(formatters={'Value': format_value})
     return '<table class="table table-striped"> \n' + table[36:len(table)]
 
 
@@ -1540,6 +1547,15 @@ def _upper_or_none(value):
     return str(value).upper()
 
 
+def _integer_display(value):
+    """Return whole-number values as integers for display."""
+    try:
+        integer_value = int(value)
+    except (TypeError, ValueError):
+        return value
+    return integer_value if integer_value == value else value
+
+
 def _nircam_pupil_rows(filter_name, paired_filter):
     short_filter = None
     long_filter = None
@@ -1609,7 +1625,6 @@ def build_timing_display_div(out, timing):
         apt_rows.append(
             ('No. of Output Channels', _nircam_output_channels(detector_config.get('subarray')))
         )
-    apt_rows.append(('Exposures/Dith', 1))
     if str(instrument).lower() == 'nircam':
         apt_rows.extend(_nircam_pupil_rows(filter_name, paired_filter))
     elif not (
@@ -1636,15 +1651,21 @@ def build_timing_display_div(out, timing):
 
     calculation_rows = [
         ('Transit Duration (hr)', timing['Transit Duration']),
-        ('Number of Transits', timing['Number of Transits']),
+        ('Number of Transits', _integer_display(timing['Number of Transits'])),
         (
             'Transit + Baseline, No Overhead (hr)',
             timing['Transit+Baseline, no overhead (hrs)']
         ),
         ('Observing Efficiency (%)', timing['Observing Efficiency (%)']),
         ('Frame Time (sec)', timing['Seconds per Frame']),
-        ('Integrations In Transit', timing['Num Integrations In Transit']),
-        ('Integrations Out of Transit', timing['Num Integrations Out of Transit']),
+        (
+            'Integrations In Transit',
+            _integer_display(timing['Num Integrations In Transit'])
+        ),
+        (
+            'Integrations Out of Transit',
+            _integer_display(timing['Num Integrations Out of Transit'])
+        ),
     ]
 
     if nstripes > 1:

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -1568,7 +1568,14 @@ def _nircam_pupil_rows(filter_name, paired_filter):
 
 
 def build_timing_display_div(out, timing):
-    """Build the browser-facing JWST timing tables."""
+    """Build browser-facing JWST APT-input and calculation-detail tables.
+
+    Returns
+    -------
+    tuple of bytes
+        HTML for the APT-input table followed by HTML for the calculation-detail
+        table. The surrounding section headings are owned by ``view.html``.
+    """
     configuration = out['input']['configuration']
     instrument_config = configuration['instrument']
     detector_config = configuration['detector']
@@ -1668,13 +1675,7 @@ def build_timing_display_div(out, timing):
             ),
         ])
 
-    timing_div = (
-        '<h3>APT Inputs</h3>\n'
-        + _table_html(apt_rows)
-        + '\n<h3>Calculation Details</h3>\n'
-        + _table_html(calculation_rows)
-    )
-    return timing_div.encode()
+    return _table_html(apt_rows).encode(), _table_html(calculation_rows).encode()
 
 
 def as_dict(out, both_spec ,binned, timing, mag, sat_level, warnings, punit, unbinned,calculation): 
@@ -1714,7 +1715,7 @@ def as_dict(out, both_spec ,binned, timing, mag, sat_level, warnings, punit, unb
 
     p=1.0
     if punit == 'fp/f*': p = -1.0
-    timing_div = build_timing_display_div(out, timing)
+    apt_div, calculation_div = build_timing_display_div(out, timing)
 
     warnings_div = pd.DataFrame.from_dict(warnings, orient='index')
     warnings_div.columns = ['Value']
@@ -1770,7 +1771,9 @@ def as_dict(out, both_spec ,binned, timing, mag, sat_level, warnings, punit, unb
     'input':input_dict,
     
     #divs for html rendering    
-    'timing_div':timing_div, 
+    'timing_div': apt_div + b'\n' + calculation_div,
+    'apt_div': apt_div,
+    'calculation_div': calculation_div,
     'input_div':input_div,
     'warnings_div':warnings_div,
     }

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -20,6 +20,10 @@ max_ngroup = {'nirspec':65535,
 #minimum number of integrations
 min_nint_trans = 3
 DHS_F150W_MIN_WAVELENGTH = 0.96
+MIRI_LRS_ALLOWED_SUBARRAYS = {
+    "lrsslitless": ("slitlessprism", "slitlessprism_ip", "slitlessprism_ips"),
+    "lrsslit": ("full", "subslit"),
+}
 
 #refdata directory
 default_refdata_directory = os.environ.get("pandeia_refdata")
@@ -60,6 +64,27 @@ def select_calculation(planet_wave_unit, nsuperstripe, is_dhs=False):
     if use_slope:
         return 'slope method'
     return 'fml'
+
+
+def validate_miri_lrs_subarray(conf):
+    """Validate MIRI LRS mode/subarray combinations supported by Pandeia."""
+    instrument = conf.get("instrument", {})
+    detector = conf.get("detector", {})
+    if str(instrument.get("instrument", "")).lower() != "miri":
+        return
+
+    mode = str(instrument.get("mode", "")).lower()
+    if mode not in MIRI_LRS_ALLOWED_SUBARRAYS:
+        return
+
+    subarray = str(detector.get("subarray", "")).lower()
+    allowed = MIRI_LRS_ALLOWED_SUBARRAYS[mode]
+    if subarray not in allowed:
+        allowed_display = ", ".join(item.upper() for item in allowed)
+        raise ValueError(
+            f"MIRI LRS {mode.upper()} supports only these subarrays: "
+            f"{allowed_display}. Got {subarray.upper()}."
+        )
 
 
 def _pandeia_1d_values_at_wave(pand_dict, key, wave):
@@ -320,6 +345,7 @@ def compute_full_sim(dictinput,verbose=False):
     #which instrument 
     instrument = pandeia_input['configuration']['instrument']['instrument']
     conf = pandeia_input['configuration']
+    validate_miri_lrs_subarray(conf)
 
     #now fix DHS #of spectra depending on the subarray
     is_dhs = 'dhs' in conf['instrument']['aperture']
@@ -349,8 +375,17 @@ def compute_full_sim(dictinput,verbose=False):
     
     #detector parameters
     det_pars = i.read_detector_pars()
-    fullwell = det_pars['fullwell']
-    rn = det_pars['rn']
+    fullwell = det_pars.get('fullwell', det_pars.get('saturation_fullwell'))
+    if fullwell is None:
+        raise KeyError(
+            "Detector parameters do not include 'fullwell' or "
+            "'saturation_fullwell'."
+        )
+    rn = det_pars.get('rn', det_pars.get('readnoise'))
+    if rn is None:
+        raise KeyError(
+            "Detector parameters do not include 'rn' or 'readnoise'."
+        )
     mingroups = det_pars['mingroups']
         
     #exposure parameters 

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -1522,7 +1522,10 @@ def _nircam_channel_mode(mode, aperture, paired_filter):
 def _display_subarray(subarray):
     if subarray is None:
         return None
-    return str(subarray).split(' (')[0].upper()
+    display_subarray = str(subarray).split(' (')[0].upper()
+    if display_subarray.endswith('_PRM'):
+        return f'{display_subarray[:-4]}_PRISM'
+    return display_subarray
 
 
 def _nircam_output_channels(subarray):
@@ -1599,6 +1602,7 @@ def build_timing_display_div(out, timing):
     instrument = instrument_config.get('instrument')
     mode = instrument_config.get('mode')
     aperture = instrument_config.get('aperture')
+    disperser = instrument_config.get('disperser')
     filter_name = instrument_config.get('filter')
     paired_filter = instrument_config.get('pandexofilterpair')
     readout_pattern = detector_config.get(
@@ -1627,6 +1631,13 @@ def build_timing_display_div(out, timing):
         )
     if str(instrument).lower() == 'nircam':
         apt_rows.extend(_nircam_pupil_rows(filter_name, paired_filter))
+    elif str(instrument).lower() == 'nirspec':
+        apt_rows.append(
+            (
+                'Grating/Filter',
+                f'{_upper_or_none(disperser)}/{_upper_or_none(filter_name)}'
+            )
+        )
     elif not (
         str(instrument).lower() == 'miri'
         and str(mode).lower() in ('lrsslitless', 'lrsslit')

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -22,7 +22,7 @@ min_nint_trans = 3
 DHS_F150W_MIN_WAVELENGTH = 0.96
 MIRI_LRS_ALLOWED_SUBARRAYS = {
     "lrsslitless": ("slitlessprism", "slitlessprism_ip", "slitlessprism_ips"),
-    "lrsslit": ("full", "subslit"),
+    "lrsslit": ("subslit", "full"),
 }
 
 #refdata directory

--- a/pandexo/engine/reference/miri_input.json
+++ b/pandexo/engine/reference/miri_input.json
@@ -54,9 +54,9 @@
            "disperser": "p750l"
            },
     "detector": {
-              "readout_pattern":"fast",
-              "subarray": "slitlessprism",
-              "readmode": "fast",
+              "readout_pattern":"fastr1",
+              "subarray": "slitlessprism_ip",
+              "readmode": "fastr1",
               "ngroup": "optimize",
               "nint": 1,
               "nexp": 10

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -40,6 +40,10 @@ PLANET_LIST_CACHE = os.environ.get(
     "PANDEXO_PLANET_LIST_CACHE",
     os.path.join(__TEMP__, "planets.csv"),
 )
+MIRI_LRS_ALLOWED_SUBARRAYS = {
+    "lrsslitless": ("slitlessprism", "slitlessprism_ip", "slitlessprism_ips"),
+    "lrsslit": ("full", "subslit"),
+}
 
 #define location of fort grids
 try:
@@ -541,10 +545,22 @@ class CalculationNewHandler(BaseHandler):
             with open(os.path.join(os.path.dirname(__file__), "reference", "miri_input.json")) as data_file:
                 pandata = json.load(data_file)
                 mirimode = self.get_argument("mirimode")
+                mirisubarray = self.get_argument("mirisubarray", "slitlessprism_ip")
+                if mirisubarray not in MIRI_LRS_ALLOWED_SUBARRAYS[mirimode]:
+                    allowed = ", ".join(
+                        item.upper() for item in MIRI_LRS_ALLOWED_SUBARRAYS[mirimode]
+                    )
+                    raise tornado.web.HTTPError(
+                        400,
+                        reason=(
+                            f"MIRI LRS {mirimode.upper()} supports only these "
+                            f"subarrays: {allowed}."
+                        ),
+                    )
                 if (mirimode == "lrsslit"):
                     pandata["configuration"]["instrument"]["mode"] = mirimode
                     pandata["configuration"]["instrument"]["aperture"] = "lrsslit"
-                    pandata["configuration"]["detector"]["subarray"] = "full"
+                pandata["configuration"]["detector"]["subarray"] = mirisubarray
 
         if instrument == "nirspec":
             with open(os.path.join(os.path.dirname(__file__), "reference", "nirspec_input.json")) as data_file:

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -42,7 +42,7 @@ PLANET_LIST_CACHE = os.environ.get(
 )
 MIRI_LRS_ALLOWED_SUBARRAYS = {
     "lrsslitless": ("slitlessprism", "slitlessprism_ip", "slitlessprism_ips"),
-    "lrsslit": ("full", "subslit"),
+    "lrsslit": ("subslit", "full"),
 }
 
 #define location of fort grids
@@ -545,7 +545,9 @@ class CalculationNewHandler(BaseHandler):
             with open(os.path.join(os.path.dirname(__file__), "reference", "miri_input.json")) as data_file:
                 pandata = json.load(data_file)
                 mirimode = self.get_argument("mirimode")
-                mirisubarray = self.get_argument("mirisubarray", "slitlessprism_ip")
+                mirisubarray = self.get_argument(
+                    "mirisubarray", MIRI_LRS_ALLOWED_SUBARRAYS[mirimode][0]
+                )
                 if mirisubarray not in MIRI_LRS_ALLOWED_SUBARRAYS[mirimode]:
                     allowed = ", ".join(
                         item.upper() for item in MIRI_LRS_ALLOWED_SUBARRAYS[mirimode]

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -44,6 +44,12 @@ MIRI_LRS_ALLOWED_SUBARRAYS = {
     "lrsslitless": ("slitlessprism", "slitlessprism_ip", "slitlessprism_ips"),
     "lrsslit": ("subslit", "full"),
 }
+NIRSPEC_PRISM_MULTISTRIPE_SUBARRAYS = (
+    "s256m2_prm",
+    "s128m4_prm",
+    "s64m8_prm",
+    "s32m16_prm",
+)
 
 #define location of fort grids
 try:
@@ -568,9 +574,21 @@ class CalculationNewHandler(BaseHandler):
             with open(os.path.join(os.path.dirname(__file__), "reference", "nirspec_input.json")) as data_file:
                 pandata = json.load(data_file)
                 nirspecmode = self.get_argument("nirspecmode")
+                nirspecsubarray = self.get_argument("nirspecsubarray")
+                if (
+                    nirspecmode != "prismclear"
+                    and nirspecsubarray in NIRSPEC_PRISM_MULTISTRIPE_SUBARRAYS
+                ):
+                    raise tornado.web.HTTPError(
+                        400,
+                        reason=(
+                            "NIRSpec PRISM multistripe subarrays are only "
+                            "available with Prism R=100 No filter."
+                        ),
+                    )
                 pandata["configuration"]["instrument"]["disperser"] = nirspecmode[0:5]
                 pandata["configuration"]["instrument"]["filter"] = nirspecmode[5:11]
-                pandata["configuration"]["detector"]["subarray"] = self.get_argument("nirspecsubarray")
+                pandata["configuration"]["detector"]["subarray"] = nirspecsubarray
 
         if instrument == "nircam":
             with open(os.path.join(os.path.dirname(__file__), "reference", "nircam_input.json")) as data_file:

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -981,7 +981,11 @@ class CalculationViewHandler(BaseHandler):
         result = self._get_task_result(id)
         
         script, div = create_component_jwst(result)
-        div['timing_div'] = result['timing_div']
+        if 'apt_div' in result:
+            div['apt_div'] = result['apt_div']
+            div['calculation_div'] = result['calculation_div']
+        else:
+            div['timing_div'] = result['timing_div']
         div['input_div'] = result['input_div'] 
         div['warnings_div'] = result['warnings_div']
 

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -378,10 +378,10 @@
                     <option value=""></option>
                     <option value="subgrism64" selected>SUBGRISM64, 4 outs(tframe=0.34)</option>
                     <option value="subgrism128">SUBGRISM128, 4 outs(tframe=0.67)</option>
-                    <option value="subgrism256">SUBGRISM258, 4 outs(tframe=1.34)</option>
+                    <option value="subgrism256">SUBGRISM256, 4 outs(tframe=1.34)</option>
                     <option value="subgrism64 (noutputs=1)">SUBGRISM64, 1 out(tframe=1.3)</option>
                     <option value="subgrism128 (noutputs=1)">SUBGRISM128, 1 out(tframe=2.6)</option>
-                    <option value="subgrism256 (noutputs=1)">SUBGRISM258, 1 out(tframe=5.2)</option>
+                    <option value="subgrism256 (noutputs=1)">SUBGRISM256, 1 out(tframe=5.2)</option>
                 </select>
             </div>
         </div>

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -357,10 +357,10 @@
                     <option value="sub1024a">S1600A1 SUB1024A</option>
                     <option value="sub1024b">S1600A1 SUB1024B</option>
                     <option value="sub512">S1600A1 SUB512</option>
-                    <option value="s256m2_prm">PRISM SUB256M2_PRISM</option>
-                    <option value="s128m4_prm">PRISM SUB128M4_PRISM</option>
-                    <option value="s64m8_prm">PRISM SUB64M8_PRISM</option>
-                    <option value="s32m16_prm">PRISM SUB32M16_PRISM</option>
+                    <option value="s256m2_prm">Multistripe SUB256M2_PRISM</option>
+                    <option value="s128m4_prm">Multistripe SUB128M4_PRISM</option>
+                    <option value="s64m8_prm">Multistripe SUB64M8_PRISM</option>
+                    <option value="s32m16_prm">Multistripe SUB32M16_PRISM</option>
                 </select>
             </div>
         </div>
@@ -376,12 +376,12 @@
             <div class="col-md-6" style="padding-right: 0;">
                 <select id="nircamsubarray" name="nircamsubarray" class="form-control" data-placeholder="Select NIRCam Subarray">
                     <option value=""></option>
-                    <option value="subgrism64" selected>SUBGRISM64, 4 outs(tframe=0.34)</option>
-                    <option value="subgrism128">SUBGRISM128, 4 outs(tframe=0.67)</option>
-                    <option value="subgrism256">SUBGRISM256, 4 outs(tframe=1.34)</option>
-                    <option value="subgrism64 (noutputs=1)">SUBGRISM64, 1 out(tframe=1.3)</option>
-                    <option value="subgrism128 (noutputs=1)">SUBGRISM128, 1 out(tframe=2.6)</option>
-                    <option value="subgrism256 (noutputs=1)">SUBGRISM256, 1 out(tframe=5.2)</option>
+                    <option value="subgrism64" selected>SUBGRISM64, 4 outs (tframe=0.34)</option>
+                    <option value="subgrism128">SUBGRISM128, 4 outs (tframe=0.67)</option>
+                    <option value="subgrism256">SUBGRISM256, 4 outs (tframe=1.34)</option>
+                    <option value="subgrism64 (noutputs=1)">SUBGRISM64, 1 out (tframe=1.3)</option>
+                    <option value="subgrism128 (noutputs=1)">SUBGRISM128, 1 out (tframe=2.6)</option>
+                    <option value="subgrism256 (noutputs=1)">SUBGRISM256, 1 out (tframe=5.2)</option>
                 </select>
             </div>
         </div>
@@ -617,6 +617,43 @@
 
         $("#mirimode").change(updateMiriSubarrayOptions);
 
+        var nirspecStandardSubarrayOptions = [
+            {value: "sub2048", label: "S1600A1 SUB2048"},
+            {value: "sub1024a", label: "S1600A1 SUB1024A"},
+            {value: "sub1024b", label: "S1600A1 SUB1024B"},
+            {value: "sub512", label: "S1600A1 SUB512"}
+        ];
+        var nirspecPrismMultistripeSubarrayOptions = [
+            {value: "s256m2_prm", label: "Multistripe SUB256M2_PRISM"},
+            {value: "s128m4_prm", label: "Multistripe SUB128M4_PRISM"},
+            {value: "s64m8_prm", label: "Multistripe SUB64M8_PRISM"},
+            {value: "s32m16_prm", label: "Multistripe SUB32M16_PRISM"}
+        ];
+
+        function updateNirspecSubarrayOptions() {
+            var mode = $("#nirspecmode").val();
+            var options = nirspecStandardSubarrayOptions.slice();
+            if (mode === "prismclear") {
+                options = options.concat(nirspecPrismMultistripeSubarrayOptions);
+            }
+            var current = $("#nirspecsubarray").val();
+            var selected = options.some(function (option) {
+                return option.value === current;
+            }) ? current : options[0].value;
+
+            $("#nirspecsubarray").empty();
+            $.each(options, function (_, option) {
+                $("<option></option>")
+                    .val(option.value)
+                    .text(option.label)
+                    .prop("selected", option.value === selected)
+                    .appendTo("#nirspecsubarray");
+            });
+            $("#nirspecsubarray").trigger("change.select2");
+        }
+
+        $("#nirspecmode").change(updateNirspecSubarrayOptions);
+
         /* Nice block level radio selection */
         $(".radio-chooser-content").click(function () {
             $(".radio-chooser-item").removeClass("radio-chooser-selected");
@@ -704,6 +741,7 @@
         $("#instrument").change(function () {
             showSelectedInstrumentMode();
             updateMiriSubarrayOptions();
+            updateNirspecSubarrayOptions();
         });
 
       //if we're editing, set the form values to what it was before
@@ -732,6 +770,7 @@
 	  });
 
           updateMiriSubarrayOptions();
+          updateNirspecSubarrayOptions();
           show_dropdown();
       }
       else {
@@ -740,6 +779,7 @@
 	  $(`input[name='planetModel'][value='constant']`).trigger("click");
 	  $(`input[name='noiseModel'][value='constant-noise']`).trigger("click");
           updateMiriSubarrayOptions();
+          updateNirspecSubarrayOptions();
       }
   });
 

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -584,20 +584,34 @@
             }, 0);
         });
 
-        var miriSubarraysByMode = {
-            lrsslitless: ["slitlessprism_ip", "slitlessprism_ips", "slitlessprism"],
-            lrsslit: ["full", "subslit"]
+        var miriSubarrayOptionsByMode = {
+            lrsslitless: [
+                {value: "slitlessprism_ip", label: "SLITLESSPRISM_IP (tframe=0.156)"},
+                {value: "slitlessprism_ips", label: "SLITLESSPRISM_IPS (tframe=0.118)"},
+                {value: "slitlessprism", label: "SLITLESSPRISM (Not Recommended, tframe=0.159)"}
+            ],
+            lrsslit: [
+                {value: "full", label: "FULL (tframe=2.775)"},
+                {value: "subslit", label: "SUBSLIT (tframe=0.279)"}
+            ]
         };
 
         function updateMiriSubarrayOptions() {
             var mode = $("#mirimode").val();
-            var allowed = miriSubarraysByMode[mode] || miriSubarraysByMode.lrsslitless;
-            $("#mirisubarray option").each(function () {
-                $(this).prop("disabled", allowed.indexOf($(this).val()) === -1);
+            var options = miriSubarrayOptionsByMode[mode] || miriSubarrayOptionsByMode.lrsslitless;
+            var current = $("#mirisubarray").val();
+            var selected = options.some(function (option) {
+                return option.value === current;
+            }) ? current : options[0].value;
+
+            $("#mirisubarray").empty();
+            $.each(options, function (_, option) {
+                $("<option></option>")
+                    .val(option.value)
+                    .text(option.label)
+                    .prop("selected", option.value === selected)
+                    .appendTo("#mirisubarray");
             });
-            if (allowed.indexOf($("#mirisubarray").val()) === -1) {
-                $("#mirisubarray").val(allowed[0]);
-            }
             $("#mirisubarray").trigger("change.select2");
         }
 

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -319,11 +319,22 @@
 
     <div class="form-group hidden" id="instrument-mode-section">
         <label class="col-md-3 control-label" for="mirimode">Mode</label>
-        <div class="col-md-4" id="MIRI">
-            <select id="mirimode" name="mirimode" class="form-control" data-placeholder="Select MIRI Mode">
-                <option value="lrsslitless" selected>Slitless LRS</option>
-                <option value="lrsslit">Slit LRS</option>
-            </select>
+        <div class="col-md-6" id="MIRI">
+            <div class="col-md-6" style="padding-left: 0;">
+                <select id="mirimode" name="mirimode" class="form-control" data-placeholder="Select MIRI Mode">
+                    <option value="lrsslitless" selected>Slitless LRS</option>
+                    <option value="lrsslit">Slit LRS</option>
+                </select>
+            </div>
+            <div class="col-md-6" style="padding-right: 0;">
+                <select id="mirisubarray" name="mirisubarray" class="form-control" data-placeholder="Select MIRI Subarray">
+                    <option value="slitlessprism_ip" selected>SLITLESSPRISM_IP (tframe=0.156)</option>
+                    <option value="slitlessprism_ips">SLITLESSPRISM_IPS (tframe=0.118)</option>
+                    <option value="slitlessprism">SLITLESSPRISM (Not Recommended, tframe=0.159)</option>
+                    <option value="full">FULL (tframe=2.775)</option>
+                    <option value="subslit">SUBSLIT (tframe=0.279)</option>
+                </select>
+            </div>
         </div>
 
         <div class="col-md-6" id="NIRSpec">
@@ -346,13 +357,17 @@
                     <option value="sub1024a">S1600A1 SUB1024A</option>
                     <option value="sub1024b">S1600A1 SUB1024B</option>
                     <option value="sub512">S1600A1 SUB512</option>
+                    <option value="s256m2_prm">PRISM SUB256M2_PRISM</option>
+                    <option value="s128m4_prm">PRISM SUB128M4_PRISM</option>
+                    <option value="s64m8_prm">PRISM SUB64M8_PRISM</option>
+                    <option value="s32m16_prm">PRISM SUB32M16_PRISM</option>
                 </select>
             </div>
         </div>
 
         <div class="col-md-6" id="NIRCam">
             <div class="col-md-6" style="padding-left: 0;">
-                <select id="nircamfilter" name="nircamfilter" onchange="showForm()" class="form-control" data-placeholder="Select NIRCam Mode">
+                <select id="nircamfilter" name="nircamfilter" class="form-control" data-placeholder="Select NIRCam Mode">
                     <option value=""></option>
                     <option value="f322w2">F322W2, 2.7-4 um</option>
                     <option value="f444w">F444W, 4-5 um</option>
@@ -373,7 +388,7 @@
 
         <div class="col-md-9" id="NIRCamDHS">
             <div class="col-md-3" style="padding-left: 0;">
-                <select id="nircamsw" name="nircamsw" onchange="showForm()" class="form-control" data-placeholder="Select SW Filter">
+                <select id="nircamsw" name="nircamsw" class="form-control" data-placeholder="Select SW Filter">
                     <option value=""></option>
                     <option value="f070w">F070W, ~0.6-0.8 um</option>
                     <option value="f090w">F090W, ~0.8-1 um</option>
@@ -383,14 +398,14 @@
                 </select>
             </div>            
             <div class="col-md-3" style="padding-left: 0;">
-                <select id="nircamlw" name="nircamlw" onchange="showForm()" class="form-control" data-placeholder="Select LW Filter">
+                <select id="nircamlw" name="nircamlw" class="form-control" data-placeholder="Select LW Filter">
                     <option value=""></option>
                     <option value="f322w2">F322W2, 2.7-4 um</option>
                     <option value="f444w">F444W, 4-5 um</option>
                 </select>
             </div>
             <div class="col-md-3" style="padding-right: 0;">
-                <select id="nircamsubarraydhs" name="nircamsubarraydhs" onchange="showForm()" class="form-control" data-placeholder="Select NIRCam Subarray">
+                <select id="nircamsubarraydhs" name="nircamsubarraydhs" class="form-control" data-placeholder="Select NIRCam Subarray">
                     <option value=""></option>
                     <option value="sub41s1_2-spectra">SUB41S1_2-SPECTRA (tframe=0.21)</option>
                     <option value="sub82s2_4-spectra">SUB82S2_4-SPECTRA (tframe=0.42)</option>
@@ -399,7 +414,7 @@
                 </select>
             </div>
             <div class="col-md-3" style="padding-right: 0;">
-                <select id="nircammode" name="nircammode" onchange="showForm()" class="form-control" data-placeholder="Display Simulation For?">
+                <select id="nircammode" name="nircammode" class="form-control" data-placeholder="Display Simulation For?">
                     <option value=""></option>
                     <option value="sw">Short wave</option>
                     <option value="lw">Long wave</option>
@@ -569,6 +584,25 @@
             }, 0);
         });
 
+        var miriSubarraysByMode = {
+            lrsslitless: ["slitlessprism_ip", "slitlessprism_ips", "slitlessprism"],
+            lrsslit: ["full", "subslit"]
+        };
+
+        function updateMiriSubarrayOptions() {
+            var mode = $("#mirimode").val();
+            var allowed = miriSubarraysByMode[mode] || miriSubarraysByMode.lrsslitless;
+            $("#mirisubarray option").each(function () {
+                $(this).prop("disabled", allowed.indexOf($(this).val()) === -1);
+            });
+            if (allowed.indexOf($("#mirisubarray").val()) === -1) {
+                $("#mirisubarray").val(allowed[0]);
+            }
+            $("#mirisubarray").trigger("change.select2");
+        }
+
+        $("#mirimode").change(updateMiriSubarrayOptions);
+
         /* Nice block level radio selection */
         $(".radio-chooser-content").click(function () {
             $(".radio-chooser-item").removeClass("radio-chooser-selected");
@@ -653,7 +687,10 @@
         }
 
         /* Instrument Selection */
-        $("#instrument").change(showSelectedInstrumentMode);
+        $("#instrument").change(function () {
+            showSelectedInstrumentMode();
+            updateMiriSubarrayOptions();
+        });
 
       //if we're editing, set the form values to what it was before
       var obj = JSON.parse($("#formDataJson").val());
@@ -680,6 +717,7 @@
 	      }
 	  });
 
+          updateMiriSubarrayOptions();
           show_dropdown();
       }
       else {
@@ -687,6 +725,7 @@
 	  $(`input[name='stellarModel'][value='phoenix']`).trigger("click");
 	  $(`input[name='planetModel'][value='constant']`).trigger("click");
 	  $(`input[name='noiseModel'][value='constant-noise']`).trigger("click");
+          updateMiriSubarrayOptions();
       }
   });
 
@@ -702,10 +741,6 @@
                 break;
         }
     }
-
-    function showForm() {
-    }
-
 
 $(function () {
   $('[data-toggle="tooltip"]').tooltip()

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -591,8 +591,8 @@
                 {value: "slitlessprism", label: "SLITLESSPRISM (Not Recommended, tframe=0.159)"}
             ],
             lrsslit: [
-                {value: "full", label: "FULL (tframe=2.775)"},
-                {value: "subslit", label: "SUBSLIT (tframe=0.279)"}
+                {value: "subslit", label: "SUBSLIT (tframe=0.279)"},
+                {value: "full", label: "FULL (tframe=2.775)"}
             ]
         };
 

--- a/pandexo/engine/templates/view.html
+++ b/pandexo/engine/templates/view.html
@@ -62,7 +62,14 @@
 <div class="container">
    <h2 id="timing">Timing Info</h2>
        <p> All the timing info needed for your observation. Overhead calculation assumes 30 minute target acquisition time.  </p>
+           {% if 'apt_div' in div %}
+           <h3>APT Inputs</h3>
+           {% raw div['apt_div']  %}
+           <h3>Calculation Details</h3>
+           {% raw div['calculation_div']  %}
+           {% else %}
            {% raw div['timing_div']  %}
+           {% end %}
 </div>
 
 

--- a/pandexo/engine/templates/view.html
+++ b/pandexo/engine/templates/view.html
@@ -2,6 +2,24 @@
 
 {% block css %}
 {% raw bokeh_css %}
+<style>
+    .pandexo-summary-table {
+        table-layout: fixed;
+        width: 100%;
+    }
+
+    .pandexo-summary-table thead th:first-child,
+    .pandexo-summary-table tbody th {
+        text-align: left;
+        width: 50%;
+    }
+
+    .pandexo-summary-table thead th:nth-child(2),
+    .pandexo-summary-table tbody td {
+        text-align: left;
+        width: 50%;
+    }
+</style>
 {% end %}
 
 {% block body %}

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -546,6 +546,71 @@ def test_nircam_lw_only_timing_display_shows_imaging_sw_channel():
     assert "GRISMR+F322W2" in html
 
 
+@pytest.mark.parametrize(
+    ('disperser', 'filter_name', 'expected'),
+    [
+        ('prism', 'clear', 'PRISM/CLEAR'),
+        ('g140h', 'f070lp', 'G140H/F070LP'),
+    ],
+)
+def test_nirspec_timing_display_combines_grating_and_filter(
+    disperser, filter_name, expected
+):
+    timing = _timing(nsuperstripe=1)
+    apt_div, calculation_div = build_timing_display_div(
+        _pandeia_out(
+            instrument={
+                'instrument': 'nirspec',
+                'mode': 'bots',
+                'filter': filter_name,
+                'aperture': 's1600a1',
+                'disperser': disperser,
+            }
+        ),
+        timing,
+    )
+    html = (apt_div + calculation_div).decode()
+
+    assert '<th>Grating/Filter</th>' in html
+    assert expected in html
+    assert '<th>Filter</th>' not in html
+
+
+@pytest.mark.parametrize(
+    ('subarray', 'expected'),
+    [
+        ('s256m2_prm', 'S256M2_PRISM'),
+        ('s128m4_prm', 'S128M4_PRISM'),
+        ('s64m8_prm', 'S64M8_PRISM'),
+        ('s32m16_prm', 'S32M16_PRISM'),
+    ],
+)
+def test_nirspec_multistripe_subarray_display_uses_prism_suffix(
+    subarray, expected
+):
+    timing = _timing(nsuperstripe=1)
+    apt_div, _ = build_timing_display_div(
+        _pandeia_out(
+            instrument={
+                'instrument': 'nirspec',
+                'mode': 'bots',
+                'filter': 'clear',
+                'aperture': 's1600a1',
+                'disperser': 'prism',
+            },
+            detector={
+                'subarray': subarray,
+                'readout_pattern': 'nrsrapid',
+            },
+        ),
+        timing,
+    )
+    html = apt_div.decode()
+
+    assert expected in html
+    assert '_PRM' not in html
+
+
 def test_miri_lrs_timing_display_uses_dither_not_filter_and_uppercase_readout():
     timing = _timing(nsuperstripe=1)
     apt_div, calculation_div = build_timing_display_div(

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -502,6 +502,32 @@ def test_nircam_lw_only_timing_display_shows_imaging_sw_channel():
     assert "GRISMR+F322W2" in html
 
 
+def test_miri_lrs_timing_display_uses_dither_not_filter_and_uppercase_readout():
+    timing = _timing(nsuperstripe=1)
+    html = build_timing_display_div(
+        _pandeia_out(
+            instrument={
+                "instrument": "miri",
+                "mode": "lrsslitless",
+                "filter": None,
+                "aperture": "imager",
+                "disperser": "p750l",
+            },
+            detector={
+                "subarray": "slitlessprism_ip",
+                "readout_pattern": "fastr1",
+            },
+        ),
+        timing,
+    ).decode()
+
+    assert "<th>Filter</th>" not in html
+    assert "<th>Dither</th>" in html
+    assert "<td>None</td>" in html
+    assert "<td>FASTR1</td>" in html
+    assert "<td>fastr1</td>" not in html
+
+
 def test_slope_uncertainty_increases_by_sqrt_nsuperstripe():
     nsuperstripe = 9
     normal = _slope_result(_timing(nsuperstripe=1))

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -15,6 +15,7 @@ from pandexo.engine.jwst import (
     compute_timing,
     select_calculation,
     update_timing_measurement_time,
+    validate_miri_lrs_subarray,
 )
 
 
@@ -561,6 +562,69 @@ def _niriss_config(subarray):
     return conf
 
 
+def _nirspec_prism_config(subarray):
+    with open("pandexo/engine/reference/nirspec_input.json") as handle:
+        conf = json.load(handle)["configuration"]
+    conf = deepcopy(conf)
+    conf["instrument"]["disperser"] = "prism"
+    conf["instrument"]["filter"] = "clear"
+    conf["detector"]["subarray"] = subarray
+    conf["detector"]["ngroup"] = 2
+    return conf
+
+
+def _miri_lrs_slit_config(subarray):
+    with open("pandexo/engine/reference/miri_input.json") as handle:
+        conf = json.load(handle)["configuration"]
+    conf = deepcopy(conf)
+    conf["instrument"]["mode"] = "lrsslit"
+    conf["instrument"]["aperture"] = "lrsslit"
+    conf["detector"]["subarray"] = subarray
+    conf["detector"]["ngroup"] = 2
+    return conf
+
+
+@pytest.mark.parametrize(
+    ("mode", "subarray"),
+    [
+        ("lrsslitless", "slitlessprism"),
+        ("lrsslitless", "slitlessprism_ip"),
+        ("lrsslitless", "slitlessprism_ips"),
+        ("lrsslit", "full"),
+        ("lrsslit", "subslit"),
+    ],
+)
+def test_validate_miri_lrs_subarray_accepts_supported_pairs(mode, subarray):
+    with open("pandexo/engine/reference/miri_input.json") as handle:
+        conf = json.load(handle)["configuration"]
+    conf = deepcopy(conf)
+    conf["instrument"]["mode"] = mode
+    conf["detector"]["subarray"] = subarray
+
+    validate_miri_lrs_subarray(conf)
+
+
+@pytest.mark.parametrize(
+    ("mode", "subarray"),
+    [
+        ("lrsslitless", "full"),
+        ("lrsslitless", "subslit"),
+        ("lrsslit", "slitlessprism"),
+        ("lrsslit", "slitlessprism_ip"),
+        ("lrsslit", "slitlessprism_ips"),
+    ],
+)
+def test_validate_miri_lrs_subarray_rejects_unsupported_pairs(mode, subarray):
+    with open("pandexo/engine/reference/miri_input.json") as handle:
+        conf = json.load(handle)["configuration"]
+    conf = deepcopy(conf)
+    conf["instrument"]["mode"] = mode
+    conf["detector"]["subarray"] = subarray
+
+    with pytest.raises(ValueError, match="MIRI LRS"):
+        validate_miri_lrs_subarray(conf)
+
+
 @pytest.mark.parametrize(
     ("subarray", "expected_nsuperstripe"),
     [
@@ -584,6 +648,51 @@ def test_pandeia_soss_multistripe_exposes_superstripes(subarray, expected_nsuper
     assert "Effective Integrations In Transit" in timing
     assert "On Source Time In Transit" in timing
     assert "Effective On Source Time In Transit" in timing
+
+
+@pytest.mark.parametrize(
+    ("subarray", "expected_nsuperstripe"),
+    [
+        ("s256m2_prm", 2),
+        ("s128m4_prm", 4),
+        ("s64m8_prm", 8),
+        ("s32m16_prm", 16),
+    ],
+)
+def test_pandeia_nirspec_prism_multistripe_exposes_superstripes(
+    subarray, expected_nsuperstripe
+):
+    _skip_if_pandeia_refdata_invalid()
+    from pandeia.engine.instrument_factory import InstrumentFactory
+
+    try:
+        exp_pars = InstrumentFactory(
+            config=_nirspec_prism_config(subarray)
+        ).the_detector.exposure_spec
+    except Exception as exc:
+        pytest.skip(f"NIRSpec PRISM multistripe subarray is unavailable: {exc}")
+
+    timing = _timing(nsuperstripe=int(getattr(exp_pars, "nsuperstripe", 1) or 1))
+
+    assert exp_pars.nsuperstripe == expected_nsuperstripe
+    assert select_calculation("um", exp_pars.nsuperstripe) == "slope method"
+    assert timing["Num Superstripes"] == expected_nsuperstripe
+    assert timing["Observing Efficiency (%)"] < 100.0
+
+
+def test_pandeia_miri_lrs_slit_supports_subslit():
+    _skip_if_pandeia_refdata_invalid()
+    from pandeia.engine.instrument_factory import InstrumentFactory
+
+    try:
+        exp_pars = InstrumentFactory(
+            config=_miri_lrs_slit_config("subslit")
+        ).the_detector.exposure_spec
+    except Exception as exc:
+        pytest.skip(f"MIRI LRS SUBSLIT subarray is unavailable: {exc}")
+
+    assert exp_pars.tframe == pytest.approx(0.27904)
+    assert exp_pars.nsuperstripe == 1
 
 
 @pytest.mark.parametrize("subarray", ["substrip96", "substrip256"])

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -11,6 +11,7 @@ import pytest
 
 from pandexo.engine.compute_noise import ExtractSpec
 from pandexo.engine.jwst import (
+    _table_html,
     add_warnings,
     build_timing_display_div,
     compute_timing,
@@ -441,6 +442,16 @@ def test_view_template_owns_timing_table_headings():
     assert "{% raw div['apt_div']  %}" in template
     assert "{% raw div['calculation_div']  %}" in template
     assert "{% raw div['timing_div']  %}" in template
+
+
+def test_summary_tables_use_shared_fixed_column_layout():
+    template = Path("pandexo/engine/templates/view.html").read_text()
+    html = _table_html([('Parameter', 'Value')])
+
+    assert 'pandexo-summary-table' in html
+    assert '.pandexo-summary-table {' in template
+    assert 'table-layout: fixed;' in template
+    assert 'width: 50%;' in template
 
 
 def test_non_multistripe_timing_display_omits_stripe_rows():

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -4,6 +4,7 @@ import contextlib
 import io
 import json
 from copy import deepcopy
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -415,10 +416,12 @@ def test_multistripe_timing_display_uses_apt_and_calculation_tables():
         exposure_time_per_int=40.0,
         ngroup=3,
     )
-    html = build_timing_display_div(_pandeia_out(), timing).decode()
+    apt_div, calculation_div = build_timing_display_div(_pandeia_out(), timing)
+    html = (apt_div + calculation_div).decode()
 
-    assert "APT Inputs" in html
-    assert "Calculation Details" in html
+    assert "APT Inputs" not in html
+    assert "Calculation Details" not in html
+    assert html.count("<table") == 2
     assert "Groups per Integration" in html
     assert "Integrations per Occultation" in html
     assert "Number of Stripes" in html
@@ -430,9 +433,20 @@ def test_multistripe_timing_display_uses_apt_and_calculation_tables():
     assert "Measurement Time per Integration" not in html
 
 
+def test_view_template_owns_timing_table_headings():
+    template = Path("pandexo/engine/templates/view.html").read_text()
+
+    assert "<h3>APT Inputs</h3>" in template
+    assert "<h3>Calculation Details</h3>" in template
+    assert "{% raw div['apt_div']  %}" in template
+    assert "{% raw div['calculation_div']  %}" in template
+    assert "{% raw div['timing_div']  %}" in template
+
+
 def test_non_multistripe_timing_display_omits_stripe_rows():
     timing = _timing(nsuperstripe=1)
-    html = build_timing_display_div(_pandeia_out(), timing).decode()
+    apt_div, calculation_div = build_timing_display_div(_pandeia_out(), timing)
+    html = (apt_div + calculation_div).decode()
 
     assert "Elapsed Time per Integration incl. Reset (sec)" in html
     assert "Science Time per Integration excl. Reset (sec)" in html
@@ -443,7 +457,7 @@ def test_non_multistripe_timing_display_omits_stripe_rows():
 
 def test_nircam_timing_display_shows_channel_and_pupil_rows():
     timing = _timing(nsuperstripe=1)
-    html = build_timing_display_div(
+    apt_div, calculation_div = build_timing_display_div(
         _pandeia_out(
             instrument={
                 "instrument": "nircam",
@@ -459,7 +473,8 @@ def test_nircam_timing_display_shows_channel_and_pupil_rows():
             },
         ),
         timing,
-    ).decode()
+    )
+    html = (apt_div + calculation_div).decode()
 
     assert "SW Channel Mode" in html
     assert "GRISM" in html
@@ -474,7 +489,7 @@ def test_nircam_timing_display_shows_channel_and_pupil_rows():
 
 def test_nircam_lw_only_timing_display_shows_imaging_sw_channel():
     timing = _timing(nsuperstripe=1)
-    html = build_timing_display_div(
+    apt_div, calculation_div = build_timing_display_div(
         _pandeia_out(
             instrument={
                 "instrument": "nircam",
@@ -489,7 +504,8 @@ def test_nircam_lw_only_timing_display_shows_imaging_sw_channel():
             },
         ),
         timing,
-    ).decode()
+    )
+    html = (apt_div + calculation_div).decode()
 
     assert "SW Channel Mode" in html
     assert "IMAGING" in html
@@ -504,7 +520,7 @@ def test_nircam_lw_only_timing_display_shows_imaging_sw_channel():
 
 def test_miri_lrs_timing_display_uses_dither_not_filter_and_uppercase_readout():
     timing = _timing(nsuperstripe=1)
-    html = build_timing_display_div(
+    apt_div, calculation_div = build_timing_display_div(
         _pandeia_out(
             instrument={
                 "instrument": "miri",
@@ -519,7 +535,8 @@ def test_miri_lrs_timing_display_uses_dither_not_filter_and_uppercase_readout():
             },
         ),
         timing,
-    ).decode()
+    )
+    html = (apt_div + calculation_div).decode()
 
     assert "<th>Filter</th>" not in html
     assert "<th>Dither</th>" in html

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -455,6 +455,23 @@ def test_non_multistripe_timing_display_omits_stripe_rows():
     assert "Science Time per Stripe" not in html
 
 
+def test_timing_display_formats_transit_and_integration_counts_as_integers():
+    timing = _timing(nsuperstripe=1)
+    timing['Number of Transits'] = 1.0
+    timing['Num Integrations In Transit'] = 12.0
+    timing['Num Integrations Out of Transit'] = 15.0
+
+    apt_div, calculation_div = build_timing_display_div(_pandeia_out(), timing)
+    html = (apt_div + calculation_div).decode()
+
+    assert "<td>1</td>" in html
+    assert "<td>12</td>" in html
+    assert "<td>15</td>" in html
+    assert "<td>1.0</td>" not in html
+    assert "<td>12.0</td>" not in html
+    assert "<td>15.0</td>" not in html
+
+
 def test_nircam_timing_display_shows_channel_and_pupil_rows():
     timing = _timing(nsuperstripe=1)
     apt_div, calculation_div = build_timing_display_div(

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -56,6 +56,8 @@ def test_base_handler_render_preserves_explicit_bokeh_resources(monkeypatch):
 
 def test_new_calculation_template_lists_new_miri_lrs_subarrays():
     template = Path("pandexo/engine/templates/new.html").read_text()
+    slit_subslit_option = 'value: "subslit", label: "SUBSLIT (tframe=0.279)"'
+    slit_full_option = 'value: "full", label: "FULL (tframe=2.775)"'
 
     assert 'value="slitlessprism_ip"' in template
     assert 'value="slitlessprism_ips"' in template
@@ -65,10 +67,17 @@ def test_new_calculation_template_lists_new_miri_lrs_subarrays():
     assert 'value="subslit"' in template
     assert "miriSubarrayOptionsByMode" in template
     assert 'lrsslit: [' in template
-    assert 'value: "full", label: "FULL (tframe=2.775)"' in template
-    assert 'value: "subslit", label: "SUBSLIT (tframe=0.279)"' in template
+    assert slit_full_option in template
+    assert slit_subslit_option in template
+    assert template.index(slit_subslit_option) < template.index(slit_full_option)
     assert ".empty()" in template
     assert ".prop(\"disabled\"" not in template
+
+
+def test_miri_lrs_slit_defaults_to_subslit():
+    from pandexo.engine.run_online import MIRI_LRS_ALLOWED_SUBARRAYS
+
+    assert MIRI_LRS_ALLOWED_SUBARRAYS["lrsslit"][0] == "subslit"
 
 
 def test_new_calculation_template_lists_nirspec_prism_multistripe_subarrays():

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -87,6 +87,33 @@ def test_new_calculation_template_lists_nirspec_prism_multistripe_subarrays():
     assert 'value="s128m4_prm"' in template
     assert 'value="s64m8_prm"' in template
     assert 'value="s32m16_prm"' in template
+    assert "Multistripe SUB256M2_PRISM" in template
+    assert "Multistripe SUB128M4_PRISM" in template
+    assert "Multistripe SUB64M8_PRISM" in template
+    assert "Multistripe SUB32M16_PRISM" in template
+    assert "PRISM SUB256M2_PRISM" not in template
+
+
+def test_new_calculation_template_gates_nirspec_multistripe_subarrays():
+    template = Path("pandexo/engine/templates/new.html").read_text()
+
+    assert "nirspecStandardSubarrayOptions" in template
+    assert "nirspecPrismMultistripeSubarrayOptions" in template
+    assert 'if (mode === "prismclear")' in template
+    assert "options.concat(nirspecPrismMultistripeSubarrayOptions)" in template
+    assert '$("#nirspecmode").change(updateNirspecSubarrayOptions)' in template
+    assert "updateNirspecSubarrayOptions();" in template
+
+
+def test_online_nirspec_multistripe_subarrays_are_prism_only():
+    from pandexo.engine.run_online import NIRSPEC_PRISM_MULTISTRIPE_SUBARRAYS
+
+    assert NIRSPEC_PRISM_MULTISTRIPE_SUBARRAYS == (
+        "s256m2_prm",
+        "s128m4_prm",
+        "s64m8_prm",
+        "s32m16_prm",
+    )
 
 
 def test_new_calculation_template_uses_subgrism256_label():

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -63,8 +63,12 @@ def test_new_calculation_template_lists_new_miri_lrs_subarrays():
     assert 'value="full"' in template
     assert "FULL (tframe=2.775)" in template
     assert 'value="subslit"' in template
-    assert "miriSubarraysByMode" in template
-    assert 'lrsslit: ["full", "subslit"]' in template
+    assert "miriSubarrayOptionsByMode" in template
+    assert 'lrsslit: [' in template
+    assert 'value: "full", label: "FULL (tframe=2.775)"' in template
+    assert 'value: "subslit", label: "SUBSLIT (tframe=0.279)"' in template
+    assert ".empty()" in template
+    assert ".prop(\"disabled\"" not in template
 
 
 def test_new_calculation_template_lists_nirspec_prism_multistripe_subarrays():

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -76,6 +76,15 @@ def test_new_calculation_template_lists_nirspec_prism_multistripe_subarrays():
     assert 'value="s32m16_prm"' in template
 
 
+def test_new_calculation_template_uses_subgrism256_label():
+    template = Path("pandexo/engine/templates/new.html").read_text()
+    bad_label = "SUBGRISM25" + "8"
+
+    assert 'value="subgrism256">SUBGRISM256' in template
+    assert 'value="subgrism256 (noutputs=1)">SUBGRISM256' in template
+    assert bad_label not in template
+
+
 def test_miri_reference_uses_supported_fastr1_readout():
     reference = Path("pandexo/engine/reference/miri_input.json").read_text()
 

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import tornado.web
 
@@ -50,3 +52,34 @@ def test_base_handler_render_preserves_explicit_bokeh_resources(monkeypatch):
 
     assert captured["kwargs"]["bokeh_css"] == "custom-css"
     assert captured["kwargs"]["bokeh_js"] == "custom-js"
+
+
+def test_new_calculation_template_lists_new_miri_lrs_subarrays():
+    template = Path("pandexo/engine/templates/new.html").read_text()
+
+    assert 'value="slitlessprism_ip"' in template
+    assert 'value="slitlessprism_ips"' in template
+    assert 'SLITLESSPRISM (Not Recommended' in template
+    assert 'value="full"' in template
+    assert "FULL (tframe=2.775)" in template
+    assert 'value="subslit"' in template
+    assert "miriSubarraysByMode" in template
+    assert 'lrsslit: ["full", "subslit"]' in template
+
+
+def test_new_calculation_template_lists_nirspec_prism_multistripe_subarrays():
+    template = Path("pandexo/engine/templates/new.html").read_text()
+
+    assert 'value="s256m2_prm"' in template
+    assert 'value="s128m4_prm"' in template
+    assert 'value="s64m8_prm"' in template
+    assert 'value="s32m16_prm"' in template
+
+
+def test_miri_reference_uses_supported_fastr1_readout():
+    reference = Path("pandexo/engine/reference/miri_input.json").read_text()
+
+    assert '"readout_pattern":"fastr1"' in reference
+    assert '"readmode": "fastr1"' in reference
+    assert '"readout_pattern":"fast"' not in reference
+    assert '"readmode": "fast"' not in reference


### PR DESCRIPTION
## Summary

- Add the new MIRI/LRS subarrays and NIRSpec PRISM multistripe subarrays introduced by the upcoming Pandeia reference-data release.
- Enforce valid MIRI/LRS slitless and slit mode/subarray combinations in both the browser workflow and offline validation; default slit observations to SUBSLIT and mark the legacy SLITLESSPRISM option as not recommended.
- Gate NIRSpec PRISM multistripe subarrays behind the PRISM mode selection and give them clear multistripe labels in `pandexo/engine/templates/new.html`.
- Update MIRI defaults to FASTR1 and SLITLESSPRISM_IP, and accept the renamed Pandeia detector parameter keys used by the release candidate.
- Correct NIRCam SUBGRISM256 labels.
- Rework the JWST timing output into APT Inputs and Calculation Details tables, with consistent fixed-column styling and backward-compatible rendering for saved calculations.
- Improve timing-table labels and formatting: show MIRI/LRS Dither instead of an empty filter, uppercase readout patterns, integer-valued transit and integration counts, NIRSpec Grating/Filter values, and user-facing `*_PRISM` multistripe subarray names.
- Expand regression coverage for the new instrument options, browser gating, timing display, and Pandeia multistripe metadata.

## Validation

- `python -m pytest tests/test_jwst_timing_noise.py`
  - 56 passed, 4 skipped
- Targeted validation was also performed against the local Pandeia and reference-data release candidates.