### PR TITLE
Optimize NIRCam readouts for data-excess constraints

### DIFF
--- a/pandexo/engine/justdoit.py
+++ b/pandexo/engine/justdoit.py
@@ -258,6 +258,10 @@ def get_thruput(inst, niriss=1, nirspec='f100lp', wmin='default', wmax='default'
     input_dict =  SetDefaultModes(inst).pick()
     conf = input_dict['configuration']
     conf['detector']['ngroup'] = 2
+    if conf['detector'].get('readout_pattern') == 'optimize':
+        # Readout cadence does not affect throughput, and Pandeia does not
+        # recognize PandExo's DHS optimization sentinel.
+        conf['detector']['readout_pattern'] = 'rapid'
 
     if conf['instrument']['instrument'].lower() =='niriss':
         conf["instrument"]["disperser"] = conf["instrument"]["disperser"] +'_'+str(niriss)

--- a/pandexo/engine/justdoit.py
+++ b/pandexo/engine/justdoit.py
@@ -260,7 +260,7 @@ def get_thruput(inst, niriss=1, nirspec='f100lp', wmin='default', wmax='default'
     conf['detector']['ngroup'] = 2
     if conf['detector'].get('readout_pattern') == 'optimize':
         # Readout cadence does not affect throughput, and Pandeia does not
-        # recognize PandExo's DHS optimization sentinel.
+        # recognize PandExo's NIRCam optimization sentinel.
         conf['detector']['readout_pattern'] = 'rapid'
 
     if conf['instrument']['instrument'].lower() =='niriss':

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -485,6 +485,20 @@ def compute_full_sim(dictinput,verbose=False):
 
     #now fix DHS #of spectra depending on the subarray
     is_dhs = 'dhs' in conf['instrument']['aperture']
+    requested_dhs_readout = str(
+        conf['detector'].get('readout_pattern', '')
+    ).lower()
+    optimize_dhs_readout = is_dhs and requested_dhs_readout == 'optimize'
+    if is_dhs:
+        if optimize_dhs_readout:
+            # Pandeia does not recognize PandExo's optimization sentinel.
+            conf['detector']['readout_pattern'] = DHS_READOUT_PATTERNS[0]
+        elif requested_dhs_readout not in DHS_READOUT_PATTERNS:
+            allowed = ', '.join(pattern.upper() for pattern in DHS_READOUT_PATTERNS)
+            raise ValueError(
+                f"Unsupported NIRCam DHS readout pattern: "
+                f"{requested_dhs_readout}. Choose optimize or one of {allowed}."
+            )
     if is_dhs:
         subarray = pandeia_input['configuration']['detector']['subarray']
         nspectra = int(subarray.split('-spectra')[0][-1])#2*int(substripe[substripe.find('stripe')+6])
@@ -618,20 +632,19 @@ def compute_full_sim(dictinput,verbose=False):
     max_ngroup_instrument = max_ngroup[pandeia_input["configuration"]["instrument"]["instrument"]]
     timing, flags = compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instrument)
 
-    if is_dhs and "maxexptime_per_int" in m:
-        maxexptime_per_int = m["maxexptime_per_int"]
+    if optimize_dhs_readout:
         selected = None
         rejected_readouts = []
         for readout_pattern in DHS_READOUT_PATTERNS:
             conf['detector']['readout_pattern'] = readout_pattern
             candidate_conf = deepcopy(conf)
-            candidate_conf['instrument']['aperture'] = 'dhs0bright'
+            if 'dhs' in candidate_conf['instrument']['aperture']:
+                candidate_conf['instrument']['aperture'] = 'dhs0bright'
             candidate_conf['detector']['ngroup'] = 2
             candidate_instrument = _instrument_factory(config=candidate_conf)
             candidate_detector = candidate_instrument.read_detector_pars()
             candidate_exposure = candidate_instrument.the_detector.exposure_spec
             candidate_m = {
-                "maxexptime_per_int": maxexptime_per_int,
                 "tframe": candidate_exposure.tframe,
                 "nframe": candidate_exposure.nframe,
                 "mingroups": candidate_detector['mingroups'],
@@ -644,6 +657,10 @@ def compute_full_sim(dictinput,verbose=False):
                 "ndrop1": getattr(candidate_exposure, "ndrop1", 0),
                 "ndrop3": getattr(candidate_exposure, "ndrop3", 0),
             }
+            if "maxexptime_per_int" in m:
+                candidate_m["maxexptime_per_int"] = m["maxexptime_per_int"]
+            else:
+                candidate_m["ngroup"] = m["ngroup"]
             candidate_timing, candidate_flags = compute_timing(
                 candidate_m,
                 transit_duration,
@@ -699,6 +716,23 @@ def compute_full_sim(dictinput,verbose=False):
             )
             + " Estimate assumes no target acquisition and a standard "
             "2,100-second initial slew."
+        )
+    elif is_dhs:
+        allocation_overhead = nircam_dhs_no_ta_overhead(tframe)
+        excess_rate, data_excess = estimate_dhs_data_excess(
+            conf['detector']['subarray'],
+            requested_dhs_readout,
+            timing['APT: Num Groups per Integration'],
+            timing['Transit+Baseline, no overhead (hrs)'],
+            allocation_overhead_seconds=allocation_overhead,
+        )
+        timing['Estimated DHS Data Excess Rate (GB/hr)'] = excess_rate
+        timing['Estimated DHS Data Excess (GB)'] = data_excess
+        timing['Assumed DHS Allocation Overhead (sec)'] = allocation_overhead
+        flags['flag_dhs_readout'] = (
+            f"User selected {requested_dhs_readout.upper()}; readout pattern "
+            "optimization was not performed. Estimate assumes no target "
+            "acquisition and a standard 2,100-second initial slew."
         )
     
     #Simulate out trans and in transit

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -1914,7 +1914,7 @@ def build_timing_display_div(out, timing):
                 f'{_upper_or_none(disperser)}/{_upper_or_none(filter_name)}'
             )
         )
-    elif not (
+    elif str(instrument).lower() != 'niriss' and not (
         str(instrument).lower() == 'miri'
         and str(mode).lower() in ('lrsslitless', 'lrsslit')
     ):

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -2126,10 +2126,7 @@ def build_timing_display_div(out, timing):
     if data_excess_mode is not None:
         data_excess_label = f'Estimated {data_excess_mode} Data Excess (GB)'
         data_excess_value = timing[data_excess_label]
-        if data_excess_mode == 'NIRCam':
-            data_excess_value = (
-                f'{data_excess_value:.1f} (Verify using APT)'
-            )
+        data_excess_value = f'{data_excess_value:.1f} (Verify using APT)'
         calculation_rows.extend([
             (
                 data_excess_label,

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -24,6 +24,31 @@ MIRI_LRS_ALLOWED_SUBARRAYS = {
     "lrsslitless": ("slitlessprism", "slitlessprism_ip", "slitlessprism_ips"),
     "lrsslit": ("subslit", "full"),
 }
+DHS_READOUT_PATTERNS = (
+    "rapid", "bright1", "dhs3", "dhs4", "dhs5", "dhs6", "dhs7"
+)
+DHS_READOUT_CADENCE_FRAMES = {
+    "rapid": 1,
+    "bright1": 2,
+    "dhs3": 3,
+    "dhs4": 4,
+    "dhs5": 5,
+    "dhs6": 6,
+    "dhs7": 7,
+}
+DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB = 15.0
+DHS_DATA_EXCESS_LOWER_THRESHOLD_GB = 5.0
+DHS_SUSTAINABLE_DATA_RATE_GB_PER_HOUR = 3.132
+DHS_NO_TA_FIXED_OVERHEAD_SECONDS = 694.0
+DHS_INITIAL_SLEW_SECONDS = 2100.0
+# Peak raw group rates calibrated from STScI's published RAPID, NGROUPS=2
+# DHS data-excess rates. These account for each supported DHS subarray size.
+DHS_RAW_GROUP_RATE_GB_PER_HOUR = {
+    "sub41s1_2-spectra": 13.728,
+    "sub82s2_4-spectra": 13.893,
+    "sub164s4_8-spectra": 13.983,
+    "sub260s4_8-spectra": 14.013,
+}
 
 #refdata directory
 default_refdata_directory = os.environ.get("pandeia_refdata")
@@ -64,6 +89,117 @@ def select_calculation(planet_wave_unit, nsuperstripe, is_dhs=False):
     if use_slope:
         return 'slope method'
     return 'fml'
+
+
+def nircam_dhs_no_ta_overhead(tframe):
+    """Return the assumed no-TA scheduling and initial-slew overhead.
+
+    The fixed 694-second scheduling component follows the documented NIRCam
+    overhead model for one grism time-series exposure without target
+    acquisition: visit scripts, guide-star acquisition, subarray and wheel
+    configuration, OSS compilation, exposure setup/cleanup, fine-guide
+    shutdown, and end-of-visit activities. Frame synchronization contributes
+    another half frame. The standard 2,100-second initial slew is then added
+    because it contributes to the nominal data allocation used by APT.
+
+    https://jwst-docs.stsci.edu/jppom/visit-overheads-timing-model/instrument-specific-overheads/nircam-overheads#gsc.tab=0
+
+    Parameters
+    ----------
+    tframe : float
+        Detector frame time in seconds.
+
+    Returns
+    -------
+    float
+        Scheduling overhead plus initial slew in seconds.
+    """
+    if not np.isfinite(tframe) or tframe <= 0:
+        raise ValueError("tframe must be a positive finite value")
+    return (
+        DHS_NO_TA_FIXED_OVERHEAD_SECONDS
+        + 0.5 * tframe
+        + DHS_INITIAL_SLEW_SECONDS
+    )
+
+
+def estimate_dhs_data_excess(
+        subarray, readout_pattern, ngroup, exposure_hours,
+        allocation_overhead_seconds=0.0):
+    """Estimate NIRCam DHS data excess for one APT exposure.
+
+    The estimate follows the data-rate relation underlying Table 2 of the
+    STScI NIRCam short-wavelength grism time-series recommendations. It
+    subtracts JWST's sustainable 3.132 GB/hour allocation from the generated
+    data rate, then scales the excess rate by the full exposure duration.
+
+    Parameters
+    ----------
+    subarray : str
+        PandExo/Pandeia DHS subarray name, such as
+        ``"sub260s4_8-spectra"``.
+    readout_pattern : str
+        One of ``RAPID``, ``BRIGHT1``, or ``DHS3`` through ``DHS7``. Matching
+        is case-insensitive.
+    ngroup : int
+        Number of groups per integration.
+    exposure_hours : float
+        Elapsed duration of the APT exposure, including integration resets,
+        in hours.
+    allocation_overhead_seconds : float, optional
+        Additional scheduling and slew duration over which APT accrues nominal
+        data allocation. The default of zero reproduces the approximate rates
+        in the STScI DHS recommendations.
+
+    Returns
+    -------
+    tuple of float
+        Estimated data-excess rate in GB/hour and total data excess in GB.
+        A negative rate means the generated rate is below the sustainable
+        allocation; the corresponding total data excess is reported as zero.
+
+    Raises
+    ------
+    ValueError
+        If the subarray, readout pattern, number of groups, or duration is not
+        supported by the estimate.
+
+    Notes
+    -----
+    This is an estimate for choosing a viable readout pattern. Users should
+    still verify final data-volume constraints in APT.
+    """
+    subarray = str(subarray).lower()
+    readout_pattern = str(readout_pattern).lower()
+    if subarray not in DHS_RAW_GROUP_RATE_GB_PER_HOUR:
+        raise ValueError(f"Unsupported NIRCam DHS subarray: {subarray}")
+    if readout_pattern not in DHS_READOUT_CADENCE_FRAMES:
+        raise ValueError(
+            f"Unsupported NIRCam DHS readout pattern: {readout_pattern}"
+        )
+    if int(ngroup) != ngroup or ngroup < 1:
+        raise ValueError("ngroup must be a positive integer")
+    if exposure_hours < 0:
+        raise ValueError("exposure_hours must be non-negative")
+    if allocation_overhead_seconds < 0:
+        raise ValueError("allocation_overhead_seconds must be non-negative")
+
+    ngroup = int(ngroup)
+    cadence_frames = DHS_READOUT_CADENCE_FRAMES[readout_pattern]
+    clock_frames = 2 + (ngroup - 1) * cadence_frames
+    generated_rate = (
+        DHS_RAW_GROUP_RATE_GB_PER_HOUR[subarray]
+        * ngroup
+        / clock_frames
+    )
+    excess_rate = generated_rate - DHS_SUSTAINABLE_DATA_RATE_GB_PER_HOUR
+    overhead_allocation = (
+        DHS_SUSTAINABLE_DATA_RATE_GB_PER_HOUR
+        * allocation_overhead_seconds
+        / 3600.0
+    )
+    total_data_excess = excess_rate * exposure_hours - overhead_allocation
+    return excess_rate, max(0.0, total_data_excess)
 
 
 def validate_miri_lrs_subarray(conf):
@@ -481,6 +617,89 @@ def compute_full_sim(dictinput,verbose=False):
     #calculate all timing info
     max_ngroup_instrument = max_ngroup[pandeia_input["configuration"]["instrument"]["instrument"]]
     timing, flags = compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instrument)
+
+    if is_dhs and "maxexptime_per_int" in m:
+        maxexptime_per_int = m["maxexptime_per_int"]
+        selected = None
+        rejected_readouts = []
+        for readout_pattern in DHS_READOUT_PATTERNS:
+            conf['detector']['readout_pattern'] = readout_pattern
+            candidate_conf = deepcopy(conf)
+            candidate_conf['instrument']['aperture'] = 'dhs0bright'
+            candidate_conf['detector']['ngroup'] = 2
+            candidate_instrument = _instrument_factory(config=candidate_conf)
+            candidate_detector = candidate_instrument.read_detector_pars()
+            candidate_exposure = candidate_instrument.the_detector.exposure_spec
+            candidate_m = {
+                "maxexptime_per_int": maxexptime_per_int,
+                "tframe": candidate_exposure.tframe,
+                "nframe": candidate_exposure.nframe,
+                "mingroups": candidate_detector['mingroups'],
+                "nskip": candidate_exposure.ndrop2,
+                "nsuperstripe": int(
+                    getattr(candidate_exposure, "nsuperstripe", 1) or 1
+                ),
+                "tfffr": getattr(candidate_exposure, "tfffr", None),
+                "nreset1": getattr(candidate_exposure, "nreset1", 1),
+                "ndrop1": getattr(candidate_exposure, "ndrop1", 0),
+                "ndrop3": getattr(candidate_exposure, "ndrop3", 0),
+            }
+            candidate_timing, candidate_flags = compute_timing(
+                candidate_m,
+                transit_duration,
+                expfact_out,
+                noccultations,
+                max_ngroup_instrument,
+            )
+            allocation_overhead = nircam_dhs_no_ta_overhead(
+                candidate_exposure.tframe
+            )
+            excess_rate, data_excess = estimate_dhs_data_excess(
+                conf['detector']['subarray'],
+                readout_pattern,
+                candidate_timing['APT: Num Groups per Integration'],
+                candidate_timing['Transit+Baseline, no overhead (hrs)'],
+                allocation_overhead_seconds=allocation_overhead,
+            )
+            candidate_timing[
+                'Estimated DHS Data Excess Rate (GB/hr)'
+            ] = excess_rate
+            candidate_timing['Estimated DHS Data Excess (GB)'] = data_excess
+            candidate_timing[
+                'Assumed DHS Allocation Overhead (sec)'
+            ] = allocation_overhead
+            selected = (
+                readout_pattern, candidate_instrument, candidate_timing,
+                candidate_flags
+            )
+
+            saturation_limited = (
+                candidate_flags['flag_default'].startswith(
+                    'Optimized NGROUPS below minimum'
+                )
+            )
+            if saturation_limited or (
+                    data_excess <= DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB):
+                break
+            rejected_readouts.append(readout_pattern.upper())
+
+        readout_pattern, i, timing, flags = selected
+        conf['detector']['readout_pattern'] = readout_pattern
+        exp_pars = i.the_detector.exposure_spec
+        tframe = exp_pars.tframe
+        nframe = exp_pars.nframe
+        nskip = exp_pars.ndrop2
+        nsuperstripe = int(getattr(exp_pars, "nsuperstripe", 1) or 1)
+        flags['flag_dhs_readout'] = (
+            f"Selected {readout_pattern.upper()}"
+            + (
+                f" after {', '.join(rejected_readouts)} exceeded the "
+                f"{DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:g} GB recommendation."
+                if rejected_readouts else "."
+            )
+            + " Estimate assumes no target acquisition and a standard "
+            "2,100-second initial slew."
+        )
     
     #Simulate out trans and in transit
     log("Starting Out of Transit Simulation")
@@ -879,7 +1098,9 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
                 )
             )
             return full_cycle
-        return (ngroups+1.0)*tframe
+        return (
+            1.0 + nframe + (ngroups - 1.0) * (nframe + nskip)
+        ) * tframe
     def _timing_values(ngroups):
         if ngroups == 1:
             frame_zero_dead = 0
@@ -1269,6 +1490,27 @@ def add_warnings(pand_dict, timing, sat_level, flags,instrument):
             "Num Groups Reset?": flags["flag_default"],
             "Minimum Integrations?": flags.get("flag_min_nint", "All good")
     }
+
+    if 'Estimated DHS Data Excess (GB)' in timing:
+        data_excess = timing['Estimated DHS Data Excess (GB)']
+        if data_excess <= DHS_DATA_EXCESS_LOWER_THRESHOLD_GB:
+            data_excess_warning = "All good"
+        elif data_excess <= DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:
+            data_excess_warning = (
+                f"Estimated data excess is {data_excess:.2f} GB, above the "
+                f"{DHS_DATA_EXCESS_LOWER_THRESHOLD_GB:g} GB lower threshold. "
+                "This is acceptable for DHS, but verify the setup in APT."
+            )
+        else:
+            data_excess_warning = (
+                f"Estimated data excess is {data_excess:.2f} GB, above the "
+                f"{DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:g} GB recommended "
+                "limit. Verify and revise the setup in APT."
+            )
+        warnings['DHS Readout Optimization'] = flags.get(
+            'flag_dhs_readout', 'User-specified readout pattern was not changed.'
+        )
+        warnings['DHS Data Excess?'] = data_excess_warning
 
     return warnings     
     
@@ -1678,6 +1920,18 @@ def build_timing_display_div(out, timing):
             _integer_display(timing['Num Integrations Out of Transit'])
         ),
     ]
+
+    if 'Estimated DHS Data Excess (GB)' in timing:
+        calculation_rows.extend([
+            (
+                'Estimated DHS Data Excess (GB)',
+                timing['Estimated DHS Data Excess (GB)']
+            ),
+            (
+                'Assumed No-TA Scheduling + Slew Overhead (sec)',
+                timing['Assumed DHS Allocation Overhead (sec)']
+            ),
+        ])
 
     if nstripes > 1:
         calculation_rows.extend([

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -2124,10 +2124,16 @@ def build_timing_display_div(out, timing):
         None,
     )
     if data_excess_mode is not None:
+        data_excess_label = f'Estimated {data_excess_mode} Data Excess (GB)'
+        data_excess_value = timing[data_excess_label]
+        if data_excess_mode == 'NIRCam':
+            data_excess_value = (
+                f'{data_excess_value:.1f} (Verify using APT)'
+            )
         calculation_rows.extend([
             (
-                f'Estimated {data_excess_mode} Data Excess (GB)',
-                timing[f'Estimated {data_excess_mode} Data Excess (GB)']
+                data_excess_label,
+                data_excess_value,
             ),
             (
                 'Assumed No-TA Scheduling + Slew Overhead (sec)',

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -36,9 +36,30 @@ DHS_READOUT_CADENCE_FRAMES = {
     "dhs6": 6,
     "dhs7": 7,
 }
-DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB = 15.0
-DHS_DATA_EXCESS_LOWER_THRESHOLD_GB = 5.0
-DHS_SUSTAINABLE_DATA_RATE_GB_PER_HOUR = 3.132
+NIRCAM_READOUT_PATTERNS = (
+    "rapid", "bright1", "bright2", "shallow2", "shallow4", "medium2",
+    "medium8", "mediumdeep2", "mediumdeep8", "deep2", "deep8",
+)
+NIRCAM_READOUT_PARAMETERS = {
+    "rapid": (1, 1),
+    "bright1": (2, 1),
+    "bright2": (2, 2),
+    "shallow2": (5, 2),
+    "shallow4": (5, 4),
+    "medium2": (10, 2),
+    "medium8": (10, 8),
+    "mediumdeep2": (15, 2),
+    "mediumdeep8": (15, 8),
+    "deep2": (20, 2),
+    "deep8": (20, 8),
+}
+NIRCAM_DATA_EXCESS_RECOMMENDED_LIMIT_GB = 15.0
+NIRCAM_DATA_EXCESS_LOWER_THRESHOLD_GB = 5.0
+NIRCAM_SUSTAINABLE_DATA_RATE_GB_PER_HOUR = 3.132
+# Backward-compatible names retained for downstream imports.
+DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB = NIRCAM_DATA_EXCESS_RECOMMENDED_LIMIT_GB
+DHS_DATA_EXCESS_LOWER_THRESHOLD_GB = NIRCAM_DATA_EXCESS_LOWER_THRESHOLD_GB
+DHS_SUSTAINABLE_DATA_RATE_GB_PER_HOUR = NIRCAM_SUSTAINABLE_DATA_RATE_GB_PER_HOUR
 DHS_NO_TA_FIXED_OVERHEAD_SECONDS = 694.0
 DHS_INITIAL_SLEW_SECONDS = 2100.0
 # Peak raw group rates calibrated from STScI's published RAPID, NGROUPS=2
@@ -49,6 +70,11 @@ DHS_RAW_GROUP_RATE_GB_PER_HOUR = {
     "sub164s4_8-spectra": 13.983,
     "sub260s4_8-spectra": 14.013,
 }
+# RAPID data generation for the three detectors used by a standard NIRCam
+# grism time series, calibrated against APT's reported data excess. One-output
+# subarrays take four times longer to read and generate groups at one quarter
+# of the four-output rate.
+NIRCAM_RAW_GROUP_RATE_GB_PER_HOUR = {4: 8.60103, 1: 2.1502575}
 
 #refdata directory
 default_refdata_directory = os.environ.get("pandeia_refdata")
@@ -91,7 +117,7 @@ def select_calculation(planet_wave_unit, nsuperstripe, is_dhs=False):
     return 'fml'
 
 
-def nircam_dhs_no_ta_overhead(tframe):
+def nircam_no_ta_overhead(tframe):
     """Return the assumed no-TA scheduling and initial-slew overhead.
 
     The fixed 694-second scheduling component follows the documented NIRCam
@@ -121,6 +147,11 @@ def nircam_dhs_no_ta_overhead(tframe):
         + 0.5 * tframe
         + DHS_INITIAL_SLEW_SECONDS
     )
+
+
+def nircam_dhs_no_ta_overhead(tframe):
+    """Return the NIRCam no-TA overhead using the legacy DHS helper name."""
+    return nircam_no_ta_overhead(tframe)
 
 
 def estimate_dhs_data_excess(
@@ -192,9 +223,80 @@ def estimate_dhs_data_excess(
         * ngroup
         / clock_frames
     )
-    excess_rate = generated_rate - DHS_SUSTAINABLE_DATA_RATE_GB_PER_HOUR
+    excess_rate = generated_rate - NIRCAM_SUSTAINABLE_DATA_RATE_GB_PER_HOUR
     overhead_allocation = (
-        DHS_SUSTAINABLE_DATA_RATE_GB_PER_HOUR
+        NIRCAM_SUSTAINABLE_DATA_RATE_GB_PER_HOUR
+        * allocation_overhead_seconds
+        / 3600.0
+    )
+    total_data_excess = excess_rate * exposure_hours - overhead_allocation
+    return excess_rate, max(0.0, total_data_excess)
+
+
+def estimate_nircam_data_excess(
+        subarray, readout_pattern, ngroup, exposure_hours,
+        allocation_overhead_seconds=0.0):
+    """Estimate data excess for a standard NIRCam grism time series.
+
+    The standard grism template records two short-wave detectors and one
+    long-wave detector. The estimate scales their RAPID data-generation rate
+    by the selected readout cadence and accounts for the additional Frame 0
+    product saved by patterns that average multiple frames into each group.
+
+    Parameters
+    ----------
+    subarray : str
+        A standard NIRCam grism subarray, optionally including the PandExo
+        ``"(noutputs=1)"`` qualifier.
+    readout_pattern : str
+        One of the standard NIRCam readout patterns from ``RAPID`` through
+        ``DEEP8``. Matching is case-insensitive.
+    ngroup : int
+        Number of groups per integration.
+    exposure_hours : float
+        Elapsed duration of the APT exposure in hours.
+    allocation_overhead_seconds : float, optional
+        Scheduling and slew duration over which APT accrues nominal data
+        allocation.
+
+    Returns
+    -------
+    tuple of float
+        Estimated data-excess rate in GB/hour and total data excess in GB.
+
+    Notes
+    -----
+    This estimate is intended to select a practical readout pattern. Final
+    data-volume constraints should still be checked in APT.
+    """
+    subarray = str(subarray).lower()
+    readout_pattern = str(readout_pattern).lower()
+    if not subarray.startswith("subgrism"):
+        raise ValueError(f"Unsupported standard NIRCam subarray: {subarray}")
+    if readout_pattern not in NIRCAM_READOUT_PARAMETERS:
+        raise ValueError(
+            f"Unsupported standard NIRCam readout pattern: {readout_pattern}"
+        )
+    if int(ngroup) != ngroup or ngroup < 1:
+        raise ValueError("ngroup must be a positive integer")
+    if exposure_hours < 0:
+        raise ValueError("exposure_hours must be non-negative")
+    if allocation_overhead_seconds < 0:
+        raise ValueError("allocation_overhead_seconds must be non-negative")
+
+    ngroup = int(ngroup)
+    noutputs = 1 if "noutputs=1" in subarray else 4
+    cadence_frames, nframe = NIRCAM_READOUT_PARAMETERS[readout_pattern]
+    clock_frames = 1 + nframe + (ngroup - 1) * cadence_frames
+    saved_groups = ngroup + int(nframe > 1)
+    generated_rate = (
+        NIRCAM_RAW_GROUP_RATE_GB_PER_HOUR[noutputs]
+        * saved_groups
+        / clock_frames
+    )
+    excess_rate = generated_rate - NIRCAM_SUSTAINABLE_DATA_RATE_GB_PER_HOUR
+    overhead_allocation = (
+        NIRCAM_SUSTAINABLE_DATA_RATE_GB_PER_HOUR
         * allocation_overhead_seconds
         / 3600.0
     )
@@ -485,19 +587,27 @@ def compute_full_sim(dictinput,verbose=False):
 
     #now fix DHS #of spectra depending on the subarray
     is_dhs = 'dhs' in conf['instrument']['aperture']
-    requested_dhs_readout = str(
+    is_nircam = str(instrument).lower() == 'nircam'
+    requested_nircam_readout = str(
         conf['detector'].get('readout_pattern', '')
     ).lower()
-    optimize_dhs_readout = is_dhs and requested_dhs_readout == 'optimize'
-    if is_dhs:
-        if optimize_dhs_readout:
+    readout_patterns = (
+        DHS_READOUT_PATTERNS if is_dhs else NIRCAM_READOUT_PATTERNS
+    )
+    optimize_nircam_readout = (
+        is_nircam and requested_nircam_readout == 'optimize'
+    )
+    if is_nircam:
+        if optimize_nircam_readout:
             # Pandeia does not recognize PandExo's optimization sentinel.
-            conf['detector']['readout_pattern'] = DHS_READOUT_PATTERNS[0]
-        elif requested_dhs_readout not in DHS_READOUT_PATTERNS:
-            allowed = ', '.join(pattern.upper() for pattern in DHS_READOUT_PATTERNS)
+            conf['detector']['readout_pattern'] = readout_patterns[0]
+        elif requested_nircam_readout not in readout_patterns:
+            allowed = ', '.join(pattern.upper() for pattern in readout_patterns)
+            mode_name = 'DHS' if is_dhs else 'standard grism'
             raise ValueError(
-                f"Unsupported NIRCam DHS readout pattern: "
-                f"{requested_dhs_readout}. Choose optimize or one of {allowed}."
+                f"Unsupported NIRCam {mode_name} readout pattern: "
+                f"{requested_nircam_readout}. Choose optimize or one of "
+                f"{allowed}."
             )
     if is_dhs:
         subarray = pandeia_input['configuration']['detector']['subarray']
@@ -632,10 +742,10 @@ def compute_full_sim(dictinput,verbose=False):
     max_ngroup_instrument = max_ngroup[pandeia_input["configuration"]["instrument"]["instrument"]]
     timing, flags = compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instrument)
 
-    if optimize_dhs_readout:
+    if optimize_nircam_readout:
         selected = None
         rejected_readouts = []
-        for readout_pattern in DHS_READOUT_PATTERNS:
+        for readout_pattern in readout_patterns:
             conf['detector']['readout_pattern'] = readout_pattern
             candidate_conf = deepcopy(conf)
             if 'dhs' in candidate_conf['instrument']['aperture']:
@@ -668,22 +778,28 @@ def compute_full_sim(dictinput,verbose=False):
                 noccultations,
                 max_ngroup_instrument,
             )
-            allocation_overhead = nircam_dhs_no_ta_overhead(
+            allocation_overhead = nircam_no_ta_overhead(
                 candidate_exposure.tframe
             )
-            excess_rate, data_excess = estimate_dhs_data_excess(
-                conf['detector']['subarray'],
-                readout_pattern,
+            estimate_data_excess = (
+                estimate_dhs_data_excess
+                if is_dhs else estimate_nircam_data_excess
+            )
+            excess_rate, data_excess = estimate_data_excess(
+                conf['detector']['subarray'], readout_pattern,
                 candidate_timing['APT: Num Groups per Integration'],
                 candidate_timing['Transit+Baseline, no overhead (hrs)'],
                 allocation_overhead_seconds=allocation_overhead,
             )
+            data_label = 'DHS' if is_dhs else 'NIRCam'
             candidate_timing[
-                'Estimated DHS Data Excess Rate (GB/hr)'
+                f'Estimated {data_label} Data Excess Rate (GB/hr)'
             ] = excess_rate
-            candidate_timing['Estimated DHS Data Excess (GB)'] = data_excess
             candidate_timing[
-                'Assumed DHS Allocation Overhead (sec)'
+                f'Estimated {data_label} Data Excess (GB)'
+            ] = data_excess
+            candidate_timing[
+                f'Assumed {data_label} Allocation Overhead (sec)'
             ] = allocation_overhead
             selected = (
                 readout_pattern, candidate_instrument, candidate_timing,
@@ -696,9 +812,10 @@ def compute_full_sim(dictinput,verbose=False):
                 )
             )
             if saturation_limited or (
-                    data_excess <= DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB):
+                    data_excess <= NIRCAM_DATA_EXCESS_RECOMMENDED_LIMIT_GB):
                 break
-            rejected_readouts.append(readout_pattern.upper())
+            if readout_pattern != readout_patterns[-1]:
+                rejected_readouts.append(readout_pattern.upper())
 
         readout_pattern, i, timing, flags = selected
         conf['detector']['readout_pattern'] = readout_pattern
@@ -707,21 +824,24 @@ def compute_full_sim(dictinput,verbose=False):
         nframe = exp_pars.nframe
         nskip = exp_pars.ndrop2
         nsuperstripe = int(getattr(exp_pars, "nsuperstripe", 1) or 1)
-        flags['flag_dhs_readout'] = (
+        flags['flag_nircam_readout'] = (
             f"Selected {readout_pattern.upper()}"
             + (
                 f" after {', '.join(rejected_readouts)} exceeded the "
-                f"{DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:g} GB recommendation."
+                f"{NIRCAM_DATA_EXCESS_RECOMMENDED_LIMIT_GB:g} GB "
+                "recommendation."
                 if rejected_readouts else "."
             )
             + " Estimate assumes no target acquisition and a standard "
             "2,100-second initial slew."
         )
+        if is_dhs:
+            flags['flag_dhs_readout'] = flags['flag_nircam_readout']
     elif is_dhs:
-        allocation_overhead = nircam_dhs_no_ta_overhead(tframe)
+        allocation_overhead = nircam_no_ta_overhead(tframe)
         excess_rate, data_excess = estimate_dhs_data_excess(
             conf['detector']['subarray'],
-            requested_dhs_readout,
+            requested_nircam_readout,
             timing['APT: Num Groups per Integration'],
             timing['Transit+Baseline, no overhead (hrs)'],
             allocation_overhead_seconds=allocation_overhead,
@@ -730,7 +850,25 @@ def compute_full_sim(dictinput,verbose=False):
         timing['Estimated DHS Data Excess (GB)'] = data_excess
         timing['Assumed DHS Allocation Overhead (sec)'] = allocation_overhead
         flags['flag_dhs_readout'] = (
-            f"User selected {requested_dhs_readout.upper()}; readout pattern "
+            f"User selected {requested_nircam_readout.upper()}; readout pattern "
+            "optimization was not performed. Estimate assumes no target "
+            "acquisition and a standard 2,100-second initial slew."
+        )
+        flags['flag_nircam_readout'] = flags['flag_dhs_readout']
+    elif is_nircam:
+        allocation_overhead = nircam_no_ta_overhead(tframe)
+        excess_rate, data_excess = estimate_nircam_data_excess(
+            conf['detector']['subarray'],
+            requested_nircam_readout,
+            timing['APT: Num Groups per Integration'],
+            timing['Transit+Baseline, no overhead (hrs)'],
+            allocation_overhead_seconds=allocation_overhead,
+        )
+        timing['Estimated NIRCam Data Excess Rate (GB/hr)'] = excess_rate
+        timing['Estimated NIRCam Data Excess (GB)'] = data_excess
+        timing['Assumed NIRCam Allocation Overhead (sec)'] = allocation_overhead
+        flags['flag_nircam_readout'] = (
+            f"User selected {requested_nircam_readout.upper()}; readout pattern "
             "optimization was not performed. Estimate assumes no target "
             "acquisition and a standard 2,100-second initial slew."
         )
@@ -1525,26 +1663,49 @@ def add_warnings(pand_dict, timing, sat_level, flags,instrument):
             "Minimum Integrations?": flags.get("flag_min_nint", "All good")
     }
 
-    if 'Estimated DHS Data Excess (GB)' in timing:
-        data_excess = timing['Estimated DHS Data Excess (GB)']
+    data_excess_mode = next(
+        (
+            mode_name for mode_name in ('DHS', 'NIRCam')
+            if f'Estimated {mode_name} Data Excess (GB)' in timing
+        ),
+        None,
+    )
+    if data_excess_mode is not None:
+        data_excess = timing[
+            f'Estimated {data_excess_mode} Data Excess (GB)'
+        ]
         if data_excess <= DHS_DATA_EXCESS_LOWER_THRESHOLD_GB:
             data_excess_warning = "All good"
         elif data_excess <= DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:
-            data_excess_warning = (
-                f"Estimated data excess is {data_excess:.2f} GB, above the "
-                f"{DHS_DATA_EXCESS_LOWER_THRESHOLD_GB:g} GB lower threshold. "
-                "This is acceptable for DHS, but verify the setup in APT."
-            )
+            if data_excess_mode == 'DHS':
+                data_excess_warning = (
+                    f"Estimated data excess is {data_excess:.2f} GB, above "
+                    f"the {DHS_DATA_EXCESS_LOWER_THRESHOLD_GB:g} GB lower "
+                    "threshold. This is acceptable for DHS, but verify the "
+                    "setup in APT."
+                )
+            else:
+                data_excess_warning = (
+                    f"Estimated data excess is {data_excess:.2f} GB, above "
+                    f"the {DHS_DATA_EXCESS_LOWER_THRESHOLD_GB:g} GB lower "
+                    f"threshold. It remains within the "
+                    f"{DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:g} GB "
+                    "recommendation, but verify the setup in APT."
+                )
         else:
             data_excess_warning = (
                 f"Estimated data excess is {data_excess:.2f} GB, above the "
                 f"{DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:g} GB recommended "
                 "limit. Verify and revise the setup in APT."
             )
-        warnings['DHS Readout Optimization'] = flags.get(
-            'flag_dhs_readout', 'User-specified readout pattern was not changed.'
+        warnings[f'{data_excess_mode} Readout Optimization'] = flags.get(
+            'flag_nircam_readout',
+            flags.get(
+                'flag_dhs_readout',
+                'User-specified readout pattern was not changed.',
+            ),
         )
-        warnings['DHS Data Excess?'] = data_excess_warning
+        warnings[f'{data_excess_mode} Data Excess?'] = data_excess_warning
 
     return warnings     
     
@@ -1955,15 +2116,24 @@ def build_timing_display_div(out, timing):
         ),
     ]
 
-    if 'Estimated DHS Data Excess (GB)' in timing:
+    data_excess_mode = next(
+        (
+            mode_name for mode_name in ('DHS', 'NIRCam')
+            if f'Estimated {mode_name} Data Excess (GB)' in timing
+        ),
+        None,
+    )
+    if data_excess_mode is not None:
         calculation_rows.extend([
             (
-                'Estimated DHS Data Excess (GB)',
-                timing['Estimated DHS Data Excess (GB)']
+                f'Estimated {data_excess_mode} Data Excess (GB)',
+                timing[f'Estimated {data_excess_mode} Data Excess (GB)']
             ),
             (
                 'Assumed No-TA Scheduling + Slew Overhead (sec)',
-                timing['Assumed DHS Allocation Overhead (sec)']
+                timing[
+                    f'Assumed {data_excess_mode} Allocation Overhead (sec)'
+                ]
             ),
         ])
 

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -1679,14 +1679,14 @@ def add_warnings(pand_dict, timing, sat_level, flags,instrument):
         elif data_excess <= DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:
             if data_excess_mode == 'DHS':
                 data_excess_warning = (
-                    f"Estimated data excess is {data_excess:.2f} GB, above "
+                    f"Estimated data excess is {data_excess:.1f} GB, above "
                     f"the {DHS_DATA_EXCESS_LOWER_THRESHOLD_GB:g} GB lower "
                     "threshold. This is acceptable for DHS, but verify the "
                     "setup in APT."
                 )
             else:
                 data_excess_warning = (
-                    f"Estimated data excess is {data_excess:.2f} GB, above "
+                    f"Estimated data excess is {data_excess:.1f} GB, above "
                     f"the {DHS_DATA_EXCESS_LOWER_THRESHOLD_GB:g} GB lower "
                     f"threshold. It remains within the "
                     f"{DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:g} GB "
@@ -1694,7 +1694,7 @@ def add_warnings(pand_dict, timing, sat_level, flags,instrument):
                 )
         else:
             data_excess_warning = (
-                f"Estimated data excess is {data_excess:.2f} GB, above the "
+                f"Estimated data excess is {data_excess:.1f} GB, above the "
                 f"{DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:g} GB recommended "
                 "limit. Verify and revise the setup in APT."
             )

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -609,6 +609,9 @@ def compute_full_sim(dictinput,verbose=False):
                 f"{requested_nircam_readout}. Choose optimize or one of "
                 f"{allowed}."
             )
+    dhs_optimization_confs = (
+        _nircam_dhs_optimization_configs(conf) if is_dhs else None
+    )
     if is_dhs:
         subarray = pandeia_input['configuration']['detector']['subarray']
         nspectra = int(subarray.split('-spectra')[0][-1])#2*int(substripe[substripe.find('stripe')+6])
@@ -633,23 +636,39 @@ def compute_full_sim(dictinput,verbose=False):
 
     i = _instrument_factory(config=conf_temp)
     
-    #detector parameters
+    # Detector parameters for the channel being simulated.
     det_pars = i.read_detector_pars()
-    fullwell = det_pars.get('fullwell', det_pars.get('saturation_fullwell'))
-    if fullwell is None:
-        raise KeyError(
-            "Detector parameters do not include 'fullwell' or "
-            "'saturation_fullwell'."
-        )
     rn = det_pars.get('rn', det_pars.get('readnoise'))
     if rn is None:
         raise KeyError(
             "Detector parameters do not include 'rn' or 'readnoise'."
         )
-    mingroups = det_pars['mingroups']
+
+    # DHS timing and saturation optimization describe one simultaneous APT
+    # exposure and must not depend on which channel PandExo later displays.
+    timing_instrument = i
+    timing_det_pars = det_pars
+    if is_dhs:
+        timing_conf = deepcopy(dhs_optimization_confs[0])
+        timing_conf['detector']['ngroup'] = (
+            2 if 'optimize' in str(conf['detector']['ngroup'])
+            else conf['detector']['ngroup']
+        )
+        timing_instrument = _instrument_factory(config=timing_conf)
+        timing_det_pars = timing_instrument.read_detector_pars()
+
+    fullwell = timing_det_pars.get(
+        'fullwell', timing_det_pars.get('saturation_fullwell')
+    )
+    if fullwell is None:
+        raise KeyError(
+            "Detector parameters do not include 'fullwell' or "
+            "'saturation_fullwell'."
+        )
+    mingroups = timing_det_pars['mingroups']
         
     #exposure parameters 
-    exp_pars = i.the_detector.exposure_spec
+    exp_pars = timing_instrument.the_detector.exposure_spec
     tframe = exp_pars.tframe
     nframe = exp_pars.nframe
     nskip = exp_pars.ndrop2
@@ -732,7 +751,40 @@ def compute_full_sim(dictinput,verbose=False):
     else:
         #run pandeia once to determine max exposure time per int and get exposure params
         log("Optimization Reqested: Computing Duty Cycle")
-        m = {"maxexptime_per_int":compute_maxexptime_per_int(pandeia_input, sat_level) , 
+        if is_dhs:
+            max_exposure_times = []
+            for optimization_conf in dhs_optimization_confs:
+                optimization_input = deepcopy(pandeia_input)
+                optimization_input['configuration'] = deepcopy(
+                    optimization_conf
+                )
+                optimization_detector_conf = deepcopy(optimization_conf)
+                optimization_detector_conf['detector']['ngroup'] = 2
+                optimization_detector = _instrument_factory(
+                    config=optimization_detector_conf
+                ).read_detector_pars()
+                optimization_fullwell = optimization_detector.get(
+                    'fullwell',
+                    optimization_detector.get('saturation_fullwell'),
+                )
+                optimization_sat_level = sat_level
+                if sat_unit == '%':
+                    optimization_sat_level = (
+                        pandexo_input['observation']['sat_level']
+                        / 100.0
+                        * optimization_fullwell
+                    )
+                max_exposure_times.append(
+                    compute_maxexptime_per_int(
+                        optimization_input, optimization_sat_level
+                    )
+                )
+            maxexptime_per_int = np.nanmin(max_exposure_times)
+        else:
+            maxexptime_per_int = compute_maxexptime_per_int(
+                pandeia_input, sat_level
+            )
+        m = {"maxexptime_per_int":maxexptime_per_int,
             "tframe":tframe,"nframe":nframe,"mingroups":mingroups,"nskip":nskip,
             "nsuperstripe":nsuperstripe}
         m.update(exposure_time_inputs)
@@ -747,7 +799,10 @@ def compute_full_sim(dictinput,verbose=False):
         rejected_readouts = []
         for readout_pattern in readout_patterns:
             conf['detector']['readout_pattern'] = readout_pattern
-            candidate_conf = deepcopy(conf)
+            candidate_conf = deepcopy(
+                dhs_optimization_confs[0] if is_dhs else conf
+            )
+            candidate_conf['detector']['readout_pattern'] = readout_pattern
             if 'dhs' in candidate_conf['instrument']['aperture']:
                 candidate_conf['instrument']['aperture'] = 'dhs0bright'
             candidate_conf['detector']['ngroup'] = 2
@@ -1944,6 +1999,81 @@ def _is_nircam_short_wave_filter(filter_name):
     return str(filter_name).lower().startswith(
         ('f070w', 'f090w', 'f115w', 'f150w', 'f150w2', 'f200w')
     )
+
+
+def _nircam_dhs_optimization_configs(conf):
+    """Return both channel configurations for shared DHS optimization.
+
+    NIRCam DHS and long-wave grism data are acquired simultaneously. PandExo
+    runs the two channels separately for display, but their recommended
+    readout pattern, groups, and integrations must be derived from one common
+    APT exposure configuration. PandExo therefore evaluates saturation using
+    both the short-wave DHS bright aperture and the simultaneous long-wave
+    grism, then applies the more restrictive exposure-time limit.
+
+    Parameters
+    ----------
+    conf : dict
+        Pandeia configuration for either displayed channel. The simultaneous
+        filter for the other channel must be stored in ``pandexofilterpair``.
+
+    Returns
+    -------
+    tuple of dict
+        Deep-copied short- and long-wave Pandeia configurations. The former
+        uses the ``dhs0bright`` aperture and the latter uses the LW grism.
+
+    Raises
+    ------
+    ValueError
+        If the displayed and paired filters do not provide one short-wave and
+        one long-wave filter.
+    """
+    instrument_conf = conf['instrument']
+    filters = (
+        instrument_conf.get('filter'),
+        instrument_conf.get('pandexofilterpair'),
+    )
+    short_filter = next(
+        (
+            filter_name
+            for filter_name in filters
+            if _is_nircam_short_wave_filter(filter_name)
+        ),
+        None,
+    )
+    long_filter = next(
+        (
+            filter_name
+            for filter_name in filters
+            if filter_name is not None
+            and not _is_nircam_short_wave_filter(filter_name)
+        ),
+        None,
+    )
+    if short_filter is None or long_filter is None:
+        raise ValueError(
+            "NIRCam DHS optimization requires one short-wave and one "
+            "long-wave filter across 'filter' and 'pandexofilterpair'."
+        )
+
+    short_conf = deepcopy(conf)
+    short_conf['instrument'].update(
+        filter=short_filter,
+        pandexofilterpair=long_filter,
+        mode='sw_tsgrism',
+        aperture='dhs0bright',
+        disperser='dhs0',
+    )
+    long_conf = deepcopy(conf)
+    long_conf['instrument'].update(
+        filter=long_filter,
+        pandexofilterpair=short_filter,
+        mode='lw_tsgrism',
+        aperture='lw',
+        disperser='grismr',
+    )
+    return short_conf, long_conf
 
 
 def _nircam_channel_mode(mode, aperture, paired_filter):

--- a/pandexo/engine/reference/nircam_dhs_input.json
+++ b/pandexo/engine/reference/nircam_dhs_input.json
@@ -53,7 +53,7 @@
             "disperser": "dhs0"
         },
     "detector": {
-            "readout_pattern":"rapid",
+            "readout_pattern":"optimize",
             "subarray": "sub260s4_8-spectra",
             "ngroup": "optimize",
             "nint": 1,

--- a/pandexo/engine/reference/nircam_dhs_input.json
+++ b/pandexo/engine/reference/nircam_dhs_input.json
@@ -49,6 +49,7 @@
             "instrument": "nircam",
             "mode": "sw_tsgrism",
             "filter": "f150w2",
+            "pandexofilterpair": "f322w2",
             "aperture": "dhs0spec8",
             "disperser": "dhs0"
         },

--- a/pandexo/engine/reference/nircam_input.json
+++ b/pandexo/engine/reference/nircam_input.json
@@ -53,7 +53,7 @@
             "disperser": "grismr"
         },
     "detector": {
-            "readout_pattern":"rapid",
+            "readout_pattern":"optimize",
             "subarray": "subgrism64",
             "ngroup": "optimize",
             "nint": 1,

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -595,6 +595,9 @@ class CalculationNewHandler(BaseHandler):
                 pandata = json.load(data_file)
                 pandata["configuration"]["instrument"]["filter"] = self.get_argument("nircamfilter")
                 pandata["configuration"]["detector"]["subarray"] = self.get_argument("nircamsubarray")
+                pandata["configuration"]["detector"]["readout_pattern"] = (
+                    self.get_argument("nircamreadout", "optimize")
+                )
 
         if instrument == "nircamdhs":
             with open(os.path.join(os.path.dirname(__file__), "reference", "nircam_dhs_input.json")) as data_file:

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -601,7 +601,7 @@ class CalculationNewHandler(BaseHandler):
                 pandata = json.load(data_file)
                 # SW and LW are observed together, but PandExo displays one at a time.
                 sw_or_lw = self.get_argument("nircammode")
-                filter_to_sim = "nircam{}".format(sw_or_lw)
+                filter_to_sim = f"nircam{sw_or_lw}"
                 if "sw" in filter_to_sim:
                     pair_filter = "nircamlw"
                 else:
@@ -609,6 +609,9 @@ class CalculationNewHandler(BaseHandler):
                 pandata["configuration"]["instrument"]["filter"] = self.get_argument(filter_to_sim)
                 pandata["configuration"]["instrument"]["pandexofilterpair"] = self.get_argument(pair_filter)
                 pandata["configuration"]["detector"]["subarray"] = self.get_argument("nircamsubarraydhs")
+                pandata["configuration"]["detector"]["readout_pattern"] = (
+                    self.get_argument("nircamdhsreadout", "optimize")
+                )
 
         if instrument == "niriss":
             with open(os.path.join(os.path.dirname(__file__), "reference", "niriss_input.json")) as data_file:

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -6,6 +6,16 @@
 <link href="{{ static_url('css/select2.min.css')}}" rel="stylesheet">
 <link href="{{ static_url('css/select2-bootstrap-theme.min.css')}}" rel="stylesheet">
 <link href="{{ static_url('css/icheck-bootstrap.min.css')}}" rel="stylesheet">
+<style>
+    #NIRCamDHS .dhs-control-row > div {
+        margin-bottom: 10px;
+    }
+
+    #NIRCamDHS .dhs-notes {
+        padding-left: 15px;
+        padding-right: 15px;
+    }
+</style>
 {% end %}
 
 {% block body %}
@@ -386,7 +396,7 @@
             </div>
             <div class="col-md-4" style="padding-right: 0;">
                 <select id="nircamreadout" name="nircamreadout" class="form-control" data-placeholder="Select NIRCam Readout Pattern">
-                    <option value="optimize" selected>Optimize readout pattern</option>
+                    <option value="optimize" selected>Optimize readout</option>
                     <option value="rapid">RAPID</option>
                     <option value="bright1">BRIGHT1</option>
                     <option value="bright2">BRIGHT2</option>
@@ -403,54 +413,60 @@
         </div>
 
         <div class="col-md-9" id="NIRCamDHS">
-            <div class="col-md-3" style="padding-left: 0;">
-                <select id="nircamsw" name="nircamsw" class="form-control" data-placeholder="Select SW Filter">
-                    <option value=""></option>
-                    <option value="f070w">F070W, ~0.6-0.8 um</option>
-                    <option value="f090w">F090W, ~0.8-1 um</option>
-                    <option value="f115w">F115W, ~1-1.2 um</option>
-                    <option value="f150w2">F150W2, ~1-1.9 um</option>
-                    <option value="f200w">F200W, ~1.7-2 um</option>
-                </select>
-            </div>            
-            <div class="col-md-3" style="padding-left: 0;">
-                <select id="nircamlw" name="nircamlw" class="form-control" data-placeholder="Select LW Filter">
-                    <option value=""></option>
-                    <option value="f322w2">F322W2, 2.7-4 um</option>
-                    <option value="f444w">F444W, 4-5 um</option>
-                </select>
+            <div class="row dhs-control-row">
+                <div class="col-md-2">
+                    <select id="nircamsw" name="nircamsw" class="form-control" data-placeholder="Select SW Filter">
+                        <option value=""></option>
+                        <option value="f070w">F070W, ~0.6-0.8 um</option>
+                        <option value="f090w">F090W, ~0.8-1 um</option>
+                        <option value="f115w">F115W, ~1-1.2 um</option>
+                        <option value="f150w2">F150W2, ~1-1.9 um</option>
+                        <option value="f200w">F200W, ~1.7-2 um</option>
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <select id="nircamlw" name="nircamlw" class="form-control" data-placeholder="Select LW Filter">
+                        <option value=""></option>
+                        <option value="f322w2">F322W2, 2.7-4 um</option>
+                        <option value="f444w">F444W, 4-5 um</option>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <select id="nircamsubarraydhs" name="nircamsubarraydhs" class="form-control" data-placeholder="Select NIRCam Subarray">
+                        <option value=""></option>
+                        <option value="sub41s1_2-spectra">SUB41S1_2-SPECTRA (tframe=0.21)</option>
+                        <option value="sub82s2_4-spectra">SUB82S2_4-SPECTRA (tframe=0.42)</option>
+                        <option value="sub164s4_8-spectra">SUB164S4_8-SPECTRA (tframe=0.84)</option>
+                        <option value="sub260s4_8-spectra">SUB260S4_8-SPECTRA (tframe=1.3)</option>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <select id="nircamdhsreadout" name="nircamdhsreadout" class="form-control" data-placeholder="Select DHS Readout Pattern">
+                        <option value="optimize" selected>Optimize readout</option>
+                        <option value="rapid">RAPID</option>
+                        <option value="bright1">BRIGHT1</option>
+                        <option value="dhs3">DHS3</option>
+                        <option value="dhs4">DHS4</option>
+                        <option value="dhs5">DHS5</option>
+                        <option value="dhs6">DHS6</option>
+                        <option value="dhs7">DHS7</option>
+                    </select>
+                </div>
             </div>
-            <div class="col-md-3" style="padding-right: 0;">
-                <select id="nircamsubarraydhs" name="nircamsubarraydhs" class="form-control" data-placeholder="Select NIRCam Subarray">
-                    <option value=""></option>
-                    <option value="sub41s1_2-spectra">SUB41S1_2-SPECTRA (tframe=0.21)</option>
-                    <option value="sub82s2_4-spectra">SUB82S2_4-SPECTRA (tframe=0.42)</option>
-                    <option value="sub164s4_8-spectra"> SUB164S4_8-SPECTRA (tframe=0.84)</option>
-                    <option value="sub260s4_8-spectra">SUB260S4_8-SPECTRA (tframe=1.3)</option>
-                </select>
+            <div class="row dhs-control-row">
+                <div class="col-md-6">
+                    <select id="nircammode" name="nircammode" class="form-control" data-placeholder="Display Simulation For?">
+                        <option value=""></option>
+                        <option value="sw">Short wave</option>
+                        <option value="lw">Long wave</option>
+                    </select>
+                </div>
             </div>
-            <div class="col-md-3" style="padding-right: 0;">
-                <select id="nircammode" name="nircammode" class="form-control" data-placeholder="Display Simulation For?">
-                    <option value=""></option>
-                    <option value="sw">Short wave</option>
-                    <option value="lw">Long wave</option>
-                </select>
-            </div>
-            <div class="col-md-3" style="padding-left: 0;">
-                <select id="nircamdhsreadout" name="nircamdhsreadout" class="form-control" data-placeholder="Select DHS Readout Pattern">
-                    <option value="optimize" selected>Optimize readout pattern</option>
-                    <option value="rapid">RAPID</option>
-                    <option value="bright1">BRIGHT1</option>
-                    <option value="dhs3">DHS3</option>
-                    <option value="dhs4">DHS4</option>
-                    <option value="dhs5">DHS5</option>
-                    <option value="dhs6">DHS6</option>
-                    <option value="dhs7">DHS7</option>
-                </select>
-            </div>
-            <div class="col-md-9" style="padding-right: 0;">
-            <p class="help-block">1) There are separate calculations for the short and long wavelength channels even though these observations occur simultaneously. Take caution to use the same Instrument Setup and Detector Setup in both the SW Grism Time Series and LW Grism Time Series calculations for a given target to correctly evaluate expected SNR. </p>
-            <p class="help-block">2) SW Filter wavelength ranges cited in the dropdown menu are only for guidance. The exact numbers dependt on the choice of LW filter <a href="https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-observing-modes/nircam-time-series-observations/nircam-short-wavelength-grism-time-series#gsc.tab=0">(see JDOX Table 3)</a></p>
+            <div class="row">
+                <div class="col-md-12 dhs-notes">
+                    <p class="help-block">1) There are separate calculations for the short and long wavelength channels even though these observations occur simultaneously. Take caution to use the same Instrument Setup and Detector Setup in both the SW Grism Time Series and LW Grism Time Series calculations for a given target to correctly evaluate expected SNR.</p>
+                    <p class="help-block">2) SW Filter wavelength ranges cited in the dropdown menu are only for guidance. The exact numbers depend on the choice of LW filter <a href="https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-observing-modes/nircam-time-series-observations/nircam-short-wavelength-grism-time-series#gsc.tab=0">(see JDOX Table 3)</a></p>
+                </div>
             </div>
         </div>
 

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -420,6 +420,18 @@
                     <option value="lw">Long wave</option>
                 </select>
             </div>
+            <div class="col-md-3" style="padding-left: 0;">
+                <select id="nircamdhsreadout" name="nircamdhsreadout" class="form-control" data-placeholder="Select DHS Readout Pattern">
+                    <option value="optimize" selected>Optimize readout pattern</option>
+                    <option value="rapid">RAPID</option>
+                    <option value="bright1">BRIGHT1</option>
+                    <option value="dhs3">DHS3</option>
+                    <option value="dhs4">DHS4</option>
+                    <option value="dhs5">DHS5</option>
+                    <option value="dhs6">DHS6</option>
+                    <option value="dhs7">DHS7</option>
+                </select>
+            </div>
             <div class="col-md-9" style="padding-right: 0;">
             <p class="help-block">1) There are separate calculations for the short and long wavelength channels even though these observations occur simultaneously. Take caution to use the same Instrument Setup and Detector Setup in both the SW Grism Time Series and LW Grism Time Series calculations for a given target to correctly evaluate expected SNR. </p>
             <p class="help-block">2) SW Filter wavelength ranges cited in the dropdown menu are only for guidance. The exact numbers dependt on the choice of LW filter <a href="https://jwst-docs.stsci.edu/jwst-near-infrared-camera/nircam-observing-modes/nircam-time-series-observations/nircam-short-wavelength-grism-time-series#gsc.tab=0">(see JDOX Table 3)</a></p>

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -414,7 +414,7 @@
 
         <div class="col-md-9" id="NIRCamDHS">
             <div class="row dhs-control-row">
-                <div class="col-md-2">
+                <div class="col-md-3 dhs-selector-column">
                     <select id="nircamsw" name="nircamsw" class="form-control" data-placeholder="Select SW Filter">
                         <option value=""></option>
                         <option value="f070w">F070W, ~0.6-0.8 um</option>
@@ -424,14 +424,14 @@
                         <option value="f200w">F200W, ~1.7-2 um</option>
                     </select>
                 </div>
-                <div class="col-md-2">
+                <div class="col-md-3 dhs-selector-column">
                     <select id="nircamlw" name="nircamlw" class="form-control" data-placeholder="Select LW Filter">
                         <option value=""></option>
                         <option value="f322w2">F322W2, 2.7-4 um</option>
                         <option value="f444w">F444W, 4-5 um</option>
                     </select>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3 dhs-selector-column">
                     <select id="nircamsubarraydhs" name="nircamsubarraydhs" class="form-control" data-placeholder="Select NIRCam Subarray">
                         <option value=""></option>
                         <option value="sub41s1_2-spectra">SUB41S1_2-SPECTRA (tframe=0.21)</option>
@@ -440,7 +440,7 @@
                         <option value="sub260s4_8-spectra">SUB260S4_8-SPECTRA (tframe=1.3)</option>
                     </select>
                 </div>
-                <div class="col-md-4">
+                <div class="col-md-3 dhs-selector-column">
                     <select id="nircamdhsreadout" name="nircamdhsreadout" class="form-control" data-placeholder="Select DHS Readout Pattern">
                         <option value="optimize" selected>Optimize readout</option>
                         <option value="rapid">RAPID</option>
@@ -454,7 +454,7 @@
                 </div>
             </div>
             <div class="row dhs-control-row">
-                <div class="col-md-6">
+                <div class="col-md-3 dhs-selector-column">
                     <select id="nircammode" name="nircammode" class="form-control" data-placeholder="Display Simulation For?">
                         <option value=""></option>
                         <option value="sw">Short wave</option>

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -365,15 +365,15 @@
             </div>
         </div>
 
-        <div class="col-md-6" id="NIRCam">
-            <div class="col-md-6" style="padding-left: 0;">
+        <div class="col-md-9" id="NIRCam">
+            <div class="col-md-4" style="padding-left: 0;">
                 <select id="nircamfilter" name="nircamfilter" class="form-control" data-placeholder="Select NIRCam Mode">
                     <option value=""></option>
                     <option value="f322w2">F322W2, 2.7-4 um</option>
                     <option value="f444w">F444W, 4-5 um</option>
                 </select>
             </div>
-            <div class="col-md-6" style="padding-right: 0;">
+            <div class="col-md-4">
                 <select id="nircamsubarray" name="nircamsubarray" class="form-control" data-placeholder="Select NIRCam Subarray">
                     <option value=""></option>
                     <option value="subgrism64" selected>SUBGRISM64, 4 outs (tframe=0.34)</option>
@@ -382,6 +382,22 @@
                     <option value="subgrism64 (noutputs=1)">SUBGRISM64, 1 out (tframe=1.3)</option>
                     <option value="subgrism128 (noutputs=1)">SUBGRISM128, 1 out (tframe=2.6)</option>
                     <option value="subgrism256 (noutputs=1)">SUBGRISM256, 1 out (tframe=5.2)</option>
+                </select>
+            </div>
+            <div class="col-md-4" style="padding-right: 0;">
+                <select id="nircamreadout" name="nircamreadout" class="form-control" data-placeholder="Select NIRCam Readout Pattern">
+                    <option value="optimize" selected>Optimize readout pattern</option>
+                    <option value="rapid">RAPID</option>
+                    <option value="bright1">BRIGHT1</option>
+                    <option value="bright2">BRIGHT2</option>
+                    <option value="shallow2">SHALLOW2</option>
+                    <option value="shallow4">SHALLOW4</option>
+                    <option value="medium2">MEDIUM2</option>
+                    <option value="medium8">MEDIUM8</option>
+                    <option value="mediumdeep2">MEDIUMDEEP2</option>
+                    <option value="mediumdeep8">MEDIUMDEEP8</option>
+                    <option value="deep2">DEEP2</option>
+                    <option value="deep8">DEEP8</option>
                 </select>
             </div>
         </div>

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -13,12 +13,15 @@ from pandexo.engine.compute_noise import ExtractSpec
 from pandexo.engine.jwst import (
     DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB,
     DHS_READOUT_PATTERNS,
+    NIRCAM_READOUT_PATTERNS,
     _table_html,
     add_warnings,
     build_timing_display_div,
     compute_timing,
     estimate_dhs_data_excess,
+    estimate_nircam_data_excess,
     nircam_dhs_no_ta_overhead,
+    nircam_no_ta_overhead,
     select_calculation,
     update_timing_measurement_time,
     validate_miri_lrs_subarray,
@@ -63,6 +66,7 @@ def test_dhs_no_ta_overhead_includes_standard_initial_slew():
     overhead = nircam_dhs_no_ta_overhead(tframe=1.36765)
 
     assert overhead == pytest.approx(2794.683825)
+    assert overhead == nircam_no_ta_overhead(tframe=1.36765)
 
 
 def test_dhs_data_excess_uses_no_ta_allocation_overhead():
@@ -79,6 +83,76 @@ def test_dhs_data_excess_uses_no_ta_allocation_overhead():
 
     assert without_overhead == pytest.approx(9.006139368, abs=1e-6)
     assert with_overhead == pytest.approx(6.574764707, abs=1e-6)
+
+
+def test_standard_nircam_optimizer_reaches_first_recommended_readout():
+    selected = None
+    for readout in NIRCAM_READOUT_PATTERNS:
+        _, total = estimate_nircam_data_excess(
+            "subgrism64", readout, ngroup=100, exposure_hours=6.0
+        )
+        if total <= DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:
+            selected = readout
+            break
+
+    assert selected == "bright1"
+
+
+def test_standard_nircam_one_output_subarray_can_retain_rapid():
+    rate, total = estimate_nircam_data_excess(
+        "subgrism64 (noutputs=1)", "rapid", ngroup=100,
+        exposure_hours=6.0,
+    )
+
+    assert rate < 0
+    assert total == 0
+
+
+def test_standard_nircam_multiframe_readout_includes_frame_zero():
+    bright1_rate, _ = estimate_nircam_data_excess(
+        "subgrism64", "bright1", ngroup=2, exposure_hours=1.0
+    )
+    bright2_rate, _ = estimate_nircam_data_excess(
+        "subgrism64", "bright2", ngroup=2, exposure_hours=1.0
+    )
+
+    assert bright2_rate > bright1_rate
+
+
+def test_standard_nircam_data_excess_matches_apt_bright1_setup():
+    _, total = estimate_nircam_data_excess(
+        "subgrism64",
+        "bright1",
+        ngroup=14,
+        exposure_hours=21622.625 / 3600.0,
+        allocation_overhead_seconds=nircam_no_ta_overhead(0.34061),
+    )
+
+    assert total == pytest.approx(4.5875, abs=0.002)
+
+
+def test_standard_nircam_data_excess_warning_is_exposed():
+    timing = _timing(nsuperstripe=1)
+    timing["Estimated NIRCam Data Excess (GB)"] = 10.0
+    warnings = add_warnings(
+        {"warnings": {}},
+        timing,
+        sat_level=0.8,
+        flags={
+            "flag_default": "All good",
+            "flag_high": "All good",
+            "flag_min_nint": "All good",
+            "flag_nircam_readout": "Selected BRIGHT1 after RAPID.",
+        },
+        instrument="nircam",
+    )
+
+    assert warnings["NIRCam Readout Optimization"].startswith(
+        "Selected BRIGHT1"
+    )
+    assert "above the 5 GB lower threshold" in warnings[
+        "NIRCam Data Excess?"
+    ]
 
 
 def _timing(nsuperstripe, ngroup=3, mingroups=2):

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -610,13 +610,16 @@ def test_multistripe_timing_display_uses_apt_and_calculation_tables():
 
 def test_timing_display_includes_estimated_dhs_data_excess():
     timing = _timing(nsuperstripe=1)
-    timing["Estimated DHS Data Excess (GB)"] = 4.25
+    timing["Estimated DHS Data Excess (GB)"] = 4.26
     timing["Assumed DHS Allocation Overhead (sec)"] = 2794.68
     _, calculation_div = build_timing_display_div(_pandeia_out(), timing)
 
-    assert "Estimated DHS Data Excess (GB)" in calculation_div.decode()
-    assert "4.25" in calculation_div.decode()
-    assert "Assumed No-TA Scheduling + Slew Overhead (sec)" in calculation_div.decode()
+    html = calculation_div.decode()
+
+    assert "Estimated DHS Data Excess (GB)" in html
+    assert "4.3 (Verify using APT)" in html
+    assert "4.26" not in html
+    assert "Assumed No-TA Scheduling + Slew Overhead (sec)" in html
 
 
 def test_view_template_owns_timing_table_headings():

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -594,6 +594,15 @@ def test_timing_display_formats_transit_and_integration_counts_as_integers():
     assert "<td>15.0</td>" not in html
 
 
+def test_niriss_timing_display_omits_filter_row():
+    timing = _timing(nsuperstripe=1)
+    apt_div, _ = build_timing_display_div(_pandeia_out(), timing)
+    html = apt_div.decode()
+
+    assert "<th>Filter</th>" not in html
+    assert "<td>clear</td>" not in html
+
+
 def test_nircam_timing_display_shows_channel_and_pupil_rows():
     timing = _timing(nsuperstripe=1)
     apt_div, calculation_div = build_timing_display_div(

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -153,6 +153,8 @@ def test_standard_nircam_data_excess_warning_is_exposed():
     assert "above the 5 GB lower threshold" in warnings[
         "NIRCam Data Excess?"
     ]
+    assert "10.0 GB" in warnings["NIRCam Data Excess?"]
+    assert "10.00 GB" not in warnings["NIRCam Data Excess?"]
 
 
 def _timing(nsuperstripe, ngroup=3, mingroups=2):
@@ -583,6 +585,8 @@ def test_dhs_lower_threshold_warning_is_exposed():
     assert warnings["DHS Readout Optimization"].startswith("Selected DHS3")
     assert "above the 5 GB lower threshold" in warnings["DHS Data Excess?"]
     assert "acceptable for DHS" in warnings["DHS Data Excess?"]
+    assert "10.0 GB" in warnings["DHS Data Excess?"]
+    assert "10.00 GB" not in warnings["DHS Data Excess?"]
 
 
 def test_multistripe_timing_display_uses_apt_and_calculation_tables():

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -11,14 +11,74 @@ import pytest
 
 from pandexo.engine.compute_noise import ExtractSpec
 from pandexo.engine.jwst import (
+    DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB,
+    DHS_READOUT_PATTERNS,
     _table_html,
     add_warnings,
     build_timing_display_div,
     compute_timing,
+    estimate_dhs_data_excess,
+    nircam_dhs_no_ta_overhead,
     select_calculation,
     update_timing_measurement_time,
     validate_miri_lrs_subarray,
 )
+
+
+@pytest.mark.parametrize(
+    ("subarray", "readout", "ngroup", "expected_rate"),
+    [
+        ("sub41s1_2-spectra", "rapid", 2, 6.02),
+        ("sub260s4_8-spectra", "rapid", 2, 6.21),
+        ("sub260s4_8-spectra", "bright1", 3, 3.88),
+        ("sub260s4_8-spectra", "dhs4", 3, 1.07),
+        ("sub260s4_8-spectra", "dhs6", 3, -0.13),
+    ],
+)
+def test_dhs_data_excess_estimate_matches_stsci_table(
+    subarray, readout, ngroup, expected_rate
+):
+    rate, total = estimate_dhs_data_excess(
+        subarray, readout, ngroup, exposure_hours=2.0
+    )
+
+    assert rate == pytest.approx(expected_rate, abs=0.01)
+    assert total == pytest.approx(max(0.0, 2.0 * expected_rate), abs=0.02)
+
+
+def test_dhs_readout_order_reaches_first_recommended_six_hour_setup():
+    selected = None
+    for readout in DHS_READOUT_PATTERNS:
+        _, total = estimate_dhs_data_excess(
+            "sub260s4_8-spectra", readout, ngroup=2, exposure_hours=6.0
+        )
+        if total <= DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB:
+            selected = readout
+            break
+
+    assert selected == "dhs3"
+
+
+def test_dhs_no_ta_overhead_includes_standard_initial_slew():
+    overhead = nircam_dhs_no_ta_overhead(tframe=1.36765)
+
+    assert overhead == pytest.approx(2794.683825)
+
+
+def test_dhs_data_excess_uses_no_ta_allocation_overhead():
+    _, without_overhead = estimate_dhs_data_excess(
+        "sub260s4_8-spectra", "dhs3", 100, exposure_hours=5.7931374583
+    )
+    _, with_overhead = estimate_dhs_data_excess(
+        "sub260s4_8-spectra",
+        "dhs3",
+        100,
+        exposure_hours=5.7931374583,
+        allocation_overhead_seconds=nircam_dhs_no_ta_overhead(1.36765),
+    )
+
+    assert without_overhead == pytest.approx(9.006139368, abs=1e-6)
+    assert with_overhead == pytest.approx(6.574764707, abs=1e-6)
 
 
 def _timing(nsuperstripe, ngroup=3, mingroups=2):
@@ -224,6 +284,25 @@ def test_multigroup_measurement_time_preserves_first_minus_last_interval():
     assert timing["Measurement Time per Integration (sec)"] == pytest.approx(4.0)
 
 
+def test_skipped_frames_contribute_to_elapsed_integration_time():
+    timing, _ = compute_timing(
+        {
+            "ngroup": 3,
+            "tframe": 2.0,
+            "nframe": 1,
+            "mingroups": 2,
+            "nskip": 2,
+            "nsuperstripe": 1,
+        },
+        transit_duration=24.0,
+        expfact_out=1.0,
+        noccultations=1,
+    )
+
+    assert timing["Time/Integration incl reset (sec)"] == pytest.approx(16.0)
+    assert timing["Measurement Time per Integration (sec)"] == pytest.approx(12.0)
+
+
 def test_multistripe_effective_time_is_divided_by_nsuperstripe():
     timing = _timing(nsuperstripe=4)
 
@@ -411,6 +490,27 @@ def test_user_multistripe_timing_warns_without_changing_ngroups_below_minimum():
     assert warnings["Minimum Integrations?"] == flags["flag_min_nint"]
 
 
+def test_dhs_lower_threshold_warning_is_exposed():
+    timing = _timing(nsuperstripe=1)
+    timing["Estimated DHS Data Excess (GB)"] = 10.0
+    warnings = add_warnings(
+        {"warnings": {}},
+        timing,
+        sat_level=0.8,
+        flags={
+            "flag_default": "All good",
+            "flag_high": "All good",
+            "flag_min_nint": "All good",
+            "flag_dhs_readout": "Selected DHS3 after RAPID, BRIGHT1 exceeded the limit.",
+        },
+        instrument="nircam",
+    )
+
+    assert warnings["DHS Readout Optimization"].startswith("Selected DHS3")
+    assert "above the 5 GB lower threshold" in warnings["DHS Data Excess?"]
+    assert "acceptable for DHS" in warnings["DHS Data Excess?"]
+
+
 def test_multistripe_timing_display_uses_apt_and_calculation_tables():
     timing = _timing_with_pandeia_cycle(
         nsuperstripe=4,
@@ -432,6 +532,17 @@ def test_multistripe_timing_display_uses_apt_and_calculation_tables():
     assert "Effective Per-Wavelength" not in html
     assert "Time/Integration incl reset" not in html
     assert "Measurement Time per Integration" not in html
+
+
+def test_timing_display_includes_estimated_dhs_data_excess():
+    timing = _timing(nsuperstripe=1)
+    timing["Estimated DHS Data Excess (GB)"] = 4.25
+    timing["Assumed DHS Allocation Overhead (sec)"] = 2794.68
+    _, calculation_div = build_timing_display_div(_pandeia_out(), timing)
+
+    assert "Estimated DHS Data Excess (GB)" in calculation_div.decode()
+    assert "4.25" in calculation_div.decode()
+    assert "Assumed No-TA Scheduling + Slew Overhead (sec)" in calculation_div.decode()
 
 
 def test_view_template_owns_timing_table_headings():

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -740,6 +740,34 @@ def test_nircam_lw_only_timing_display_shows_imaging_sw_channel():
     assert "GRISMR+F322W2" in html
 
 
+def test_nircam_timing_display_formats_estimated_data_excess():
+    timing = _timing(nsuperstripe=1)
+    timing['Estimated NIRCam Data Excess (GB)'] = 4.5875
+    timing['Assumed NIRCam Allocation Overhead (sec)'] = 2794.0
+    _, calculation_div = build_timing_display_div(
+        _pandeia_out(
+            instrument={
+                "instrument": "nircam",
+                "mode": "lw_tsgrism",
+                "filter": "f322w2",
+                "aperture": "lw",
+                "disperser": "grismr",
+            },
+            detector={
+                "subarray": "subgrism64",
+                "readout_pattern": "bright1",
+            },
+        ),
+        timing,
+    )
+    html = calculation_div.decode()
+
+    assert "Estimated NIRCam Data Excess (GB)" in html
+    assert "4.6 (Verify using APT)" in html
+    assert "4.6 GB" not in html
+    assert "4.5875" not in html
+
+
 @pytest.mark.parametrize(
     ('disperser', 'filter_name', 'expected'),
     [

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -962,8 +962,32 @@ def test_pandeia_dhs_readout_uses_slope_without_superstripes():
 
     with open("pandexo/engine/reference/nircam_dhs_input.json") as handle:
         conf = json.load(handle)["configuration"]
+    assert conf["detector"]["readout_pattern"] == "optimize"
+    conf["detector"]["readout_pattern"] = "rapid"
     conf["detector"]["ngroup"] = 2
     exp_pars = InstrumentFactory(config=conf).the_detector.exposure_spec
 
     assert exp_pars.nsuperstripe == 1
     assert select_calculation("um", exp_pars.nsuperstripe, is_dhs=True) == "slope method"
+
+
+def test_dhs_throughput_resolves_optimized_readout_before_pandeia(monkeypatch):
+    from pandexo.engine import justdoit
+
+    captured = {}
+
+    class FakeInstrument:
+        def __init__(self, config):
+            captured.update(config)
+
+        def get_wave_range(self):
+            return {"wmin": 1.0, "wmax": 2.0}
+
+        def get_total_eff(self, wave):
+            return np.ones_like(wave)
+
+    monkeypatch.setattr(justdoit, "InstrumentFactory", FakeInstrument)
+
+    justdoit.get_thruput("NIRCam DHS")
+
+    assert captured["detector"]["readout_pattern"] == "rapid"

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -14,6 +14,7 @@ from pandexo.engine.jwst import (
     DHS_DATA_EXCESS_RECOMMENDED_LIMIT_GB,
     DHS_READOUT_PATTERNS,
     NIRCAM_READOUT_PATTERNS,
+    _nircam_dhs_optimization_configs,
     _table_html,
     add_warnings,
     build_timing_display_div,
@@ -155,6 +156,50 @@ def test_standard_nircam_data_excess_warning_is_exposed():
     ]
     assert "10.0 GB" in warnings["NIRCam Data Excess?"]
     assert "10.00 GB" not in warnings["NIRCam Data Excess?"]
+
+
+def test_dhs_optimization_configs_are_independent_of_displayed_channel():
+    base_conf = {
+        'instrument': {
+            'instrument': 'nircam',
+            'mode': 'sw_tsgrism',
+            'filter': 'f150w2',
+            'pandexofilterpair': 'f322w2',
+            'aperture': 'dhs0spec8',
+            'disperser': 'dhs0',
+        },
+        'detector': {
+            'readout_pattern': 'rapid',
+            'subarray': 'sub260s4_8-spectra',
+            'ngroup': 'optimize',
+        },
+    }
+    long_wave_conf = deepcopy(base_conf)
+    long_wave_conf['instrument'].update(
+        mode='lw_tsgrism',
+        filter='f322w2',
+        pandexofilterpair='f150w2',
+        aperture='lw',
+        disperser='grismr',
+    )
+
+    short_display_configs = _nircam_dhs_optimization_configs(base_conf)
+    long_display_configs = _nircam_dhs_optimization_configs(long_wave_conf)
+
+    for short_display, long_display in zip(
+        short_display_configs, long_display_configs
+    ):
+        for key in (
+            'filter', 'pandexofilterpair', 'mode', 'aperture', 'disperser'
+        ):
+            assert short_display['instrument'][key] == (
+                long_display['instrument'][key]
+            )
+        assert short_display['detector'] == long_display['detector']
+    assert short_display_configs[0]['instrument']['filter'] == 'f150w2'
+    assert short_display_configs[1]['instrument']['filter'] == 'f322w2'
+    assert base_conf['instrument']['aperture'] == 'dhs0spec8'
+    assert long_wave_conf['instrument']['aperture'] == 'lw'
 
 
 def _timing(nsuperstripe, ngroup=3, mingroups=2):

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -129,7 +129,11 @@ def test_new_calculation_template_lists_dhs_readout_patterns():
     template = Path("pandexo/engine/templates/new.html").read_text()
 
     assert 'name="nircamdhsreadout"' in template
-    assert '<option value="optimize" selected>Optimize readout pattern</option>' in template
+    assert template.count('class="row dhs-control-row"') == 2
+    assert 'class="col-md-12 dhs-notes"' in template
+    assert template.count(
+        '<option value="optimize" selected>Optimize readout</option>'
+    ) == 2
     for readout in ("rapid", "bright1", "dhs3", "dhs4", "dhs5", "dhs6", "dhs7"):
         assert f'<option value="{readout}">' in template
 

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -140,6 +140,23 @@ def test_nircam_dhs_reference_defaults_to_readout_optimization():
     assert '"readout_pattern":"optimize"' in reference
 
 
+def test_new_calculation_template_lists_standard_nircam_readout_patterns():
+    template = Path("pandexo/engine/templates/new.html").read_text()
+
+    assert 'name="nircamreadout"' in template
+    for readout in (
+        "rapid", "bright1", "bright2", "shallow2", "shallow4", "medium2",
+        "medium8", "mediumdeep2", "mediumdeep8", "deep2", "deep8",
+    ):
+        assert f'<option value="{readout}">' in template
+
+
+def test_standard_nircam_reference_defaults_to_readout_optimization():
+    reference = Path("pandexo/engine/reference/nircam_input.json").read_text()
+
+    assert '"readout_pattern":"optimize"' in reference
+
+
 def test_miri_reference_uses_supported_fastr1_readout():
     reference = Path("pandexo/engine/reference/miri_input.json").read_text()
 

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -130,6 +130,7 @@ def test_new_calculation_template_lists_dhs_readout_patterns():
 
     assert 'name="nircamdhsreadout"' in template
     assert template.count('class="row dhs-control-row"') == 2
+    assert template.count('class="col-md-3 dhs-selector-column"') == 5
     assert 'class="col-md-12 dhs-notes"' in template
     assert template.count(
         '<option value="optimize" selected>Optimize readout</option>'

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -125,6 +125,21 @@ def test_new_calculation_template_uses_subgrism256_label():
     assert bad_label not in template
 
 
+def test_new_calculation_template_lists_dhs_readout_patterns():
+    template = Path("pandexo/engine/templates/new.html").read_text()
+
+    assert 'name="nircamdhsreadout"' in template
+    assert '<option value="optimize" selected>Optimize readout pattern</option>' in template
+    for readout in ("rapid", "bright1", "dhs3", "dhs4", "dhs5", "dhs6", "dhs7"):
+        assert f'<option value="{readout}">' in template
+
+
+def test_nircam_dhs_reference_defaults_to_readout_optimization():
+    reference = Path("pandexo/engine/reference/nircam_dhs_input.json").read_text()
+
+    assert '"readout_pattern":"optimize"' in reference
+
+
 def test_miri_reference_uses_supported_fastr1_readout():
     reference = Path("pandexo/engine/reference/miri_input.json").read_text()
 


### PR DESCRIPTION
## Summary

- Optimize NIRCam readout patterns from highest to lower cadence, selecting a suitable readout, groups/integration, and integration count for the requested observation.
- Apply readout optimization to both DHS and standard NIRCam grism calculations while retaining explicit user overrides.
- Optimize simultaneous DHS short- and long-wave observations against both channels, so the selected setup is independent of which channel is displayed.
- Estimate NIRCam data excess using APT-calibrated timing assumptions and report the estimate with a reminder to verify it in APT.
- Improve the NIRCam mode-selector layout and remove the irrelevant Filter row from NIRISS SOSS output tables.

## Details

The optimizer now works through supported NIRCam readout patterns in cadence order and stops at the first configuration that satisfies the applicable saturation, minimum-integration, and data-excess constraints. For DHS observations, the saturation-limited groups/integration is determined from both simultaneously observed channels, using the more restrictive result.

Estimated data excess is rounded to one decimal place and remains explicitly identified as an estimate requiring APT verification. Users can select a specific readout pattern instead of using the optimizer.

## Testing

- Added timing/noise tests for readout selection, data-excess estimates and warnings, minimum integrations, explicit readout overrides, and paired DHS channel optimization.
- Added online-template tests for NIRCam selector options and layout.
- Full suite: 172 passed, 4 skipped.