### PR TITLE
Correct NIRSpec PRISM multistripe timing and enforce APT limits

### DIFF
--- a/pandexo/engine/compute_noise.py
+++ b/pandexo/engine/compute_noise.py
@@ -58,26 +58,29 @@ class ExtractSpec():
         self.real_nint_out = timing["Num Integrations Out of Transit"]
         self.real_nint_in = timing["Num Integrations In Transit"]
         self.nsuperstripe = timing.get("Num Superstripes", 1)
-        self.nint_out = timing.get("Effective Integrations Out of Transit",
-                                   self.real_nint_out)
-        self.nint_in = timing.get("Effective Integrations In Transit",
-                                  self.real_nint_in)
+        self.nint_out = self.real_nint_out
+        self.nint_in = self.real_nint_in
         self.tframe = timing["Seconds per Frame"]
         self.frame_zero_dead = timing["Zero Frame Efficiency Loss"]
         self.rn = rn 
         self.extraction_area = extraction_area
 
-        # Pandeia is run with nint=1. Its scalar measurement_time is the
-        # per-integration science time PandExo scales below. For SOSS
-        # multistripe modes that Pandeia value includes all superstripes, so
-        # timing supplies effective per-wavelength integration counts.
+        # Pandeia is run with nint=1. In multistripe modes measurement_time
+        # includes every stripe in one complete cycle, while each wavelength
+        # receives only the per-stripe fraction of that science time. Every
+        # completed cycle nevertheless contributes one independent ramp at
+        # every wavelength.
         self.exptime_per_int = timing.get(
             "Measurement Time per Integration (sec)",
             self.tframe * (self.ngroups_per_int+self.frame_zero_dead) * self.nsuperstripe
         )
         measurement_time_in = self.inn.get('scalar', self.out['scalar'])['measurement_time']
-        self.on_source_in = measurement_time_in * self.nint_in
-        self.on_source_out = self.out['scalar']['measurement_time'] * self.nint_out #self.tframe * (self.ngroups_per_int+self.frame_zero_dead) 
+        self.on_source_in = measurement_time_in / self.nsuperstripe * self.nint_in
+        self.on_source_out = (
+            self.out['scalar']['measurement_time']
+            / self.nsuperstripe
+            * self.nint_out
+        )
 
     def loopingL(self, cen, signal_col, noise_col, bkg_col):
         """Finds bottom of the optimal extraction region.

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -20,6 +20,8 @@ max_ngroup = {'nirspec':65535,
 #minimum number of integrations
 min_nint_trans = 3
 DHS_F150W_MIN_WAVELENGTH = 0.96
+NIRSPEC_APT_MAX_INTEGRATIONS_PER_EXPOSURE = 65535
+NIRSPEC_HGA_REPOINT_WARNING_SECONDS = 10000.0
 MIRI_LRS_ALLOWED_SUBARRAYS = {
     "lrsslitless": ("slitlessprism", "slitlessprism_ip", "slitlessprism_ips"),
     "lrsslit": ("subslit", "full"),
@@ -793,7 +795,6 @@ def compute_full_sim(dictinput,verbose=False):
     #calculate all timing info
     max_ngroup_instrument = max_ngroup[pandeia_input["configuration"]["instrument"]["instrument"]]
     timing, flags = compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instrument)
-
     if optimize_nircam_readout:
         selected = None
         rejected_readouts = []
@@ -927,6 +928,13 @@ def compute_full_sim(dictinput,verbose=False):
             "optimization was not performed. Estimate assumes no target "
             "acquisition and a standard 2,100-second initial slew."
         )
+
+    if (
+            str(instrument).lower() == "nirspec"
+            and str(conf["instrument"].get("disperser")).lower() == "prism"
+            and nsuperstripe > 1):
+        update_nirspec_prism_apt_timing(timing)
+        flags["flag_hga_repoint"] = nirspec_prism_exposure_warning(timing)
     
     #Simulate out trans and in transit
     log("Starting Out of Transit Simulation")
@@ -1466,15 +1474,17 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
     if nint_out < min_nint_trans:
         nint_out = min_nint_trans
 
-    effective_nint_in = nint_in / float(nsuperstripe)
-    effective_nint_out = nint_out / float(nsuperstripe)
-    # measurement_time_per_int is the Pandeia value for one nint=1
-    # calculation. In SOSS multistripe modes it includes all superstripes,
-    # so the per-wavelength on-source time must use effective_nint_*.
-    on_source_in = effective_nint_in * measurement_time_per_int
-    on_source_out = effective_nint_out * measurement_time_per_int
-    effective_on_source_in = effective_nint_in * measurement_time_per_int
-    effective_on_source_out = effective_nint_out * measurement_time_per_int
+    # Pandeia's nint is the number of complete multistripe cycles. Each cycle
+    # contributes one independent ramp to every stripe, so the integration
+    # count is not divided by nsuperstripe. The full-cycle measurement time is
+    # divided only when calculating the science time seen by one wavelength.
+    effective_nint_in = nint_in
+    effective_nint_out = nint_out
+    science_time_per_stripe = measurement_time_per_int / float(nsuperstripe)
+    on_source_in = nint_in * science_time_per_stripe
+    on_source_out = nint_out * science_time_per_stripe
+    effective_on_source_in = on_source_in
+    effective_on_source_out = on_source_out
    
     timing = {
         "Transit Duration" : (transit_duration)/60.0/60.0,
@@ -1508,23 +1518,22 @@ def update_timing_measurement_time(timing, measurement_time_per_int):
     """Sync timing metadata to the measurement_time reported by Pandeia.
 
     PandExo runs Pandeia with nint=1 and scales integrations internally. For
-    SOSS multistripe modes, Pandeia's one-integration measurement_time includes
-    all superstripes, so per-wavelength time uses the effective integration
-    counts in the timing dictionary.
+    multistripe modes, Pandeia's one-integration measurement time includes a
+    complete cycle through every stripe. Each wavelength receives the
+    per-stripe fraction of that time once per real integration.
     """
     nsuperstripe = float(timing.get("Num Superstripes", 1) or 1)
     nint_in = timing["Num Integrations In Transit"]
     nint_out = timing["Num Integrations Out of Transit"]
-    effective_nint_in = nint_in / nsuperstripe
-    effective_nint_out = nint_out / nsuperstripe
+    science_time_per_stripe = measurement_time_per_int / nsuperstripe
 
     timing["Measurement Time per Integration (sec)"] = measurement_time_per_int
-    timing["Effective Integrations In Transit"] = effective_nint_in
-    timing["Effective Integrations Out of Transit"] = effective_nint_out
-    timing["On Source Time In Transit"] = effective_nint_in * measurement_time_per_int
-    timing["On Source Time Out of Transit"] = effective_nint_out * measurement_time_per_int
-    timing["Effective On Source Time In Transit"] = effective_nint_in * measurement_time_per_int
-    timing["Effective On Source Time Out of Transit"] = effective_nint_out * measurement_time_per_int
+    timing["Effective Integrations In Transit"] = nint_in
+    timing["Effective Integrations Out of Transit"] = nint_out
+    timing["On Source Time In Transit"] = nint_in * science_time_per_stripe
+    timing["On Source Time Out of Transit"] = nint_out * science_time_per_stripe
+    timing["Effective On Source Time In Transit"] = timing["On Source Time In Transit"]
+    timing["Effective On Source Time Out of Transit"] = timing["On Source Time Out of Transit"]
 
 def remove_QY(pandeia_dict, instrument):
     """Removes Quantum Yield from Pandeia Fluxes. Place Holder. 
@@ -1761,6 +1770,9 @@ def add_warnings(pand_dict, timing, sat_level, flags,instrument):
             ),
         )
         warnings[f'{data_excess_mode} Data Excess?'] = data_excess_warning
+
+    if "flag_hga_repoint" in flags:
+        warnings["Exposure Duration?"] = flags["flag_hga_repoint"]
 
     return warnings     
     
@@ -2126,6 +2138,143 @@ def _integer_display(value):
     return integer_value if integer_value == value else value
 
 
+def _is_nirspec_prism_multistripe(instrument, disperser, nstripes):
+    return (
+        str(instrument).lower() == 'nirspec'
+        and str(disperser).lower() == 'prism'
+        and nstripes > 1
+    )
+
+
+def nirspec_prism_apt_parameters(
+        timing,
+        max_integrations_per_exposure=NIRSPEC_APT_MAX_INTEGRATIONS_PER_EXPOSURE):
+    """Convert Pandeia multistripe cycles into NIRSpec BOTS APT inputs.
+
+    Pandeia counts one complete pass through all stripes as one integration.
+    APT instead counts the integration performed on each individual stripe.
+    If the resulting stripe-level count exceeds APT's per-exposure limit, the
+    integrations are distributed as evenly as possible over multiple
+    ``Exposures/Dith`` entries.
+
+    Parameters
+    ----------
+    timing : dict
+        PandExo timing dictionary for a NIRSpec PRISM multistripe calculation.
+    max_integrations_per_exposure : int, optional
+        Maximum APT ``Integrations/Exp`` value. The default is 65,535.
+
+    Returns
+    -------
+    dict
+        Number of full Pandeia cycles, required and scheduled APT stripe
+        integrations, ``Exposures/Dith``, ``Integrations/Exp``, and the
+        resulting APT exposure duration in seconds.
+
+    Raises
+    ------
+    ValueError
+        If the stripe count or integration limit is not positive.
+    """
+    nstripes = int(timing.get('Num Superstripes', 1) or 1)
+    if nstripes < 1:
+        raise ValueError('Num Superstripes must be positive')
+    if max_integrations_per_exposure < 1:
+        raise ValueError('max_integrations_per_exposure must be positive')
+
+    cycles = int(
+        timing['Num Integrations In Transit']
+        + timing['Num Integrations Out of Transit']
+    )
+    required_integrations = cycles * nstripes
+    exposures_per_dither = max(
+        1,
+        int(np.ceil(
+            required_integrations / float(max_integrations_per_exposure)
+        )),
+    )
+    integrations_per_exposure = int(np.ceil(
+        required_integrations / float(exposures_per_dither)
+    ))
+    scheduled_integrations = (
+        exposures_per_dither * integrations_per_exposure
+    )
+    stripe_elapsed_time = (
+        timing['Time/Integration incl reset (sec)'] / float(nstripes)
+    )
+
+    return {
+        'cycles': cycles,
+        'required_integrations': required_integrations,
+        'scheduled_integrations': scheduled_integrations,
+        'exposures_per_dither': exposures_per_dither,
+        'integrations_per_exposure': integrations_per_exposure,
+        'stripe_elapsed_time': stripe_elapsed_time,
+        'exposure_duration': scheduled_integrations * stripe_elapsed_time,
+    }
+
+
+def nirspec_prism_exposure_warning(timing):
+    """Return APT's long-exposure guidance for PRISM multistripe BOTS.
+
+    NIRSpec BOTS observations may exceed APT's nominal 10,000-second exposure
+    limit. Such observations are permitted, but a high-gain antenna repoint can
+    briefly move the spectrum and produce a flux excursion.
+
+    Parameters
+    ----------
+    timing : dict
+        PandExo timing dictionary for a NIRSpec PRISM multistripe calculation.
+
+    Returns
+    -------
+    str
+        ``"All good"`` below the nominal limit, otherwise an informational
+        warning describing the possible repoint interruption.
+    """
+    exposure_duration = nirspec_prism_apt_parameters(
+        timing
+    )['exposure_duration']
+    if exposure_duration <= NIRSPEC_HGA_REPOINT_WARNING_SECONDS:
+        return 'All good'
+    return (
+        "APT will warn that the exposure duration exceeds 10,000 seconds. "
+        "NIRSpec BOTS permits longer exposures, but a high-gain antenna "
+        "repoint may cause an approximately 60-second flux excursion."
+    )
+
+
+def update_nirspec_prism_apt_timing(timing):
+    """Add NIRSpec PRISM multistripe APT values to a timing dictionary.
+
+    The original in- and out-of-transit counts remain Pandeia full-cycle
+    counts. APT-facing fields are converted to stripe-level integrations and
+    split across exposures where necessary.
+
+    Parameters
+    ----------
+    timing : dict
+        PandExo timing dictionary to update in place.
+
+    Returns
+    -------
+    dict
+        The updated timing dictionary.
+    """
+    apt_parameters = nirspec_prism_apt_parameters(timing)
+    timing.update({
+        'Num Multistripe Cycles per Occultation': apt_parameters['cycles'],
+        'APT: Exposures/Dith': apt_parameters['exposures_per_dither'],
+        'APT: Num Integrations per Exposure': (
+            apt_parameters['integrations_per_exposure']
+        ),
+        'APT: Num Integrations per Occultation': (
+            apt_parameters['scheduled_integrations']
+        ),
+    })
+    return timing
+
+
 def _nircam_pupil_rows(filter_name, paired_filter):
     short_filter = None
     long_filter = None
@@ -2177,6 +2326,9 @@ def build_timing_display_div(out, timing):
         detector_config.get('readmode')
     )
     nstripes = int(timing.get('Num Superstripes', 1) or 1)
+    is_nirspec_prism_multistripe = _is_nirspec_prism_multistripe(
+        instrument, disperser, nstripes
+    )
 
     apt_rows = [
         ('Instrument', _jwst_instrument_name(instrument)),
@@ -2221,11 +2373,18 @@ def build_timing_display_div(out, timing):
             'Groups per Integration',
             timing['APT: Num Groups per Integration']
         ),
-        (
+    ])
+    if is_nirspec_prism_multistripe:
+        apt_parameters = nirspec_prism_apt_parameters(timing)
+        apt_rows.extend([
+            ('Exposures/Dith', apt_parameters['exposures_per_dither']),
+            ('Integrations/Exp', apt_parameters['integrations_per_exposure']),
+        ])
+    else:
+        apt_rows.append((
             'Integrations per Occultation',
             timing['APT: Num Integrations per Occultation']
-        ),
-    ])
+        ))
 
     calculation_rows = [
         ('Transit Duration (hr)', timing['Transit Duration']),
@@ -2274,9 +2433,16 @@ def build_timing_display_div(out, timing):
         calculation_rows.extend([
             ('Number of Stripes', nstripes),
             (
-                'Elapsed Time per APT Integration incl. Reset (sec)',
+                'Elapsed Time per Full Multistripe Cycle incl. Reset (sec)',
                 timing['Time/Integration incl reset (sec)']
             ),
+        ])
+        if is_nirspec_prism_multistripe:
+            calculation_rows.append((
+                'Elapsed Time per APT Stripe Integration incl. Reset (sec)',
+                timing['Time/Integration incl reset (sec)'] / float(nstripes)
+            ))
+        calculation_rows.extend([
             (
                 'Science Time per Full Multistripe Cycle excl. Reset (sec)',
                 timing['Measurement Time per Integration (sec)']

--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -15,12 +15,13 @@ import pickle
 #max groups in integration
 max_ngroup = {'nirspec':65535,
               'miri':65535,
-              'niriss':65535,
+              'niriss':30,
               'nircam':100}
 #minimum number of integrations
 min_nint_trans = 3
 DHS_F150W_MIN_WAVELENGTH = 0.96
-NIRSPEC_APT_MAX_INTEGRATIONS_PER_EXPOSURE = 65535
+APT_MAX_INTEGRATIONS_PER_EXPOSURE = 65535
+MAX_FRAMES_PER_EXPOSURE = 196608
 NIRSPEC_HGA_REPOINT_WARNING_SECONDS = 10000.0
 MIRI_LRS_ALLOWED_SUBARRAYS = {
     "lrsslitless": ("slitlessprism", "slitlessprism_ip", "slitlessprism_ips"),
@@ -793,7 +794,7 @@ def compute_full_sim(dictinput,verbose=False):
         log("Finished Duty Cycle Calc")
 
     #calculate all timing info
-    max_ngroup_instrument = max_ngroup[pandeia_input["configuration"]["instrument"]["instrument"]]
+    max_ngroup_instrument = max_ngroup[str(instrument).lower()]
     timing, flags = compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instrument)
     if optimize_nircam_readout:
         selected = None
@@ -929,11 +930,21 @@ def compute_full_sim(dictinput,verbose=False):
             "acquisition and a standard 2,100-second initial slew."
         )
 
-    if (
+    is_nirspec_prism_multistripe = (
             str(instrument).lower() == "nirspec"
             and str(conf["instrument"].get("disperser")).lower() == "prism"
-            and nsuperstripe > 1):
-        update_nirspec_prism_apt_timing(timing)
+            and nsuperstripe > 1
+    )
+    integration_multiplier = nsuperstripe if is_nirspec_prism_multistripe else 1
+    update_apt_timing(
+        timing,
+        integration_multiplier=integration_multiplier,
+        max_frames_per_exposure=MAX_FRAMES_PER_EXPOSURE,
+        frames_per_integration=(
+            timing['APT: Num Groups per Integration'] * (nframe + nskip)
+        ),
+    )
+    if is_nirspec_prism_multistripe:
         flags["flag_hga_repoint"] = nirspec_prism_exposure_warning(timing)
     
     #Simulate out trans and in transit
@@ -1391,10 +1402,6 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
         #if you exceed that limit, set it to the maximum value instead.
         #also set another check for saturation
 
-        if ngroups_per_int > max_ngroup_instrument:
-            ngroups_per_int = max_ngroup_instrument
-            flag_high = f"Optimized NGROUPS above maximum ({max_ngroup_instrument}). SET TO NGROUPS={max_ngroup_instrument}"
- 
         if (ngroups_per_int < mingroups) | np.isnan(ngroups_per_int):
             ngroups_per_int = mingroups
             nframes_per_int = mingroups
@@ -1411,6 +1418,16 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
         ngroups_per_int = mingroups
         nframes_per_int = mingroups
         flag_default = f"Something went wrong. SET TO NGROUPS={mingroups}"
+
+    if ngroups_per_int > max_ngroup_instrument:
+        original_ngroups_per_int = ngroups_per_int
+        ngroups_per_int = max_ngroup_instrument
+        source = "Optimized" if optimized_ngroups else "User-specified"
+        flag_high = (
+            f"{source} NGROUPS ({int(original_ngroups_per_int)}) exceeds "
+            f"the maximum ({int(max_ngroup_instrument)}). SET TO "
+            f"NGROUPS={int(max_ngroup_instrument)}"
+        )
 
     timing_values = _timing_values(ngroups_per_int)
     frame_zero_dead = timing_values["frame_zero_dead"]
@@ -2146,9 +2163,101 @@ def _is_nirspec_prism_multistripe(instrument, disperser, nstripes):
     )
 
 
+def apt_exposure_parameters(
+        timing,
+        integration_multiplier=1,
+        max_integrations_per_exposure=APT_MAX_INTEGRATIONS_PER_EXPOSURE,
+        max_frames_per_exposure=None,
+        frames_per_integration=None):
+    """Split an observation into valid APT exposures.
+
+    Parameters
+    ----------
+    timing : dict
+        PandExo timing dictionary.
+    integration_multiplier : int, optional
+        Number of APT integrations represented by one PandExo integration.
+        This is one for ordinary modes and the stripe count for NIRSpec PRISM
+        multistripe observations.
+    max_integrations_per_exposure : int, optional
+        Universal maximum number of integrations in one APT exposure. The
+        default is 65,535.
+    max_frames_per_exposure : int, optional
+        Additional instrument limit on the number of frames in one exposure.
+    frames_per_integration : int, optional
+        Number of detector frames in one APT integration. Required when
+        ``max_frames_per_exposure`` is supplied.
+
+    Returns
+    -------
+    dict
+        Required and scheduled integrations, exposures per dither,
+        integrations per exposure, and the resulting exposure duration.
+
+    Raises
+    ------
+    ValueError
+        If a supplied count or limit is not positive.
+    """
+    integration_multiplier = int(integration_multiplier)
+    if integration_multiplier < 1:
+        raise ValueError('integration_multiplier must be positive')
+    if max_integrations_per_exposure < 1:
+        raise ValueError('max_integrations_per_exposure must be positive')
+
+    effective_limit = int(max_integrations_per_exposure)
+    if max_frames_per_exposure is not None:
+        if frames_per_integration is None:
+            raise ValueError(
+                'frames_per_integration is required with a frame limit'
+            )
+        frames_per_integration = int(frames_per_integration)
+        if frames_per_integration < 1 or max_frames_per_exposure < 1:
+            raise ValueError('frame counts and limits must be positive')
+        frame_limited_integrations = int(
+            max_frames_per_exposure // frames_per_integration
+        )
+        if frame_limited_integrations < 1:
+            raise ValueError(
+                'one integration exceeds the maximum frames per exposure'
+            )
+        effective_limit = min(effective_limit, frame_limited_integrations)
+
+    integrations = int(
+        timing['Num Integrations In Transit']
+        + timing['Num Integrations Out of Transit']
+    )
+    required_integrations = integrations * integration_multiplier
+    exposures_per_dither = max(
+        1,
+        int(np.ceil(required_integrations / float(effective_limit))),
+    )
+    integrations_per_exposure = int(np.ceil(
+        required_integrations / float(exposures_per_dither)
+    ))
+    scheduled_integrations = exposures_per_dither * integrations_per_exposure
+    elapsed_time_per_apt_integration = (
+        timing['Time/Integration incl reset (sec)']
+        / float(integration_multiplier)
+    )
+
+    return {
+        'integrations': integrations,
+        'required_integrations': required_integrations,
+        'scheduled_integrations': scheduled_integrations,
+        'exposures_per_dither': exposures_per_dither,
+        'integrations_per_exposure': integrations_per_exposure,
+        'elapsed_time_per_apt_integration': elapsed_time_per_apt_integration,
+        'exposure_duration': (
+            scheduled_integrations * elapsed_time_per_apt_integration
+        ),
+        'max_integrations_per_exposure': effective_limit,
+    }
+
+
 def nirspec_prism_apt_parameters(
         timing,
-        max_integrations_per_exposure=NIRSPEC_APT_MAX_INTEGRATIONS_PER_EXPOSURE):
+        max_integrations_per_exposure=APT_MAX_INTEGRATIONS_PER_EXPOSURE):
     """Convert Pandeia multistripe cycles into NIRSpec BOTS APT inputs.
 
     Pandeia counts one complete pass through all stripes as one integration.
@@ -2179,39 +2288,16 @@ def nirspec_prism_apt_parameters(
     nstripes = int(timing.get('Num Superstripes', 1) or 1)
     if nstripes < 1:
         raise ValueError('Num Superstripes must be positive')
-    if max_integrations_per_exposure < 1:
-        raise ValueError('max_integrations_per_exposure must be positive')
-
-    cycles = int(
-        timing['Num Integrations In Transit']
-        + timing['Num Integrations Out of Transit']
+    parameters = apt_exposure_parameters(
+        timing,
+        integration_multiplier=nstripes,
+        max_integrations_per_exposure=max_integrations_per_exposure,
     )
-    required_integrations = cycles * nstripes
-    exposures_per_dither = max(
-        1,
-        int(np.ceil(
-            required_integrations / float(max_integrations_per_exposure)
-        )),
+    parameters['cycles'] = parameters.pop('integrations')
+    parameters['stripe_elapsed_time'] = parameters.pop(
+        'elapsed_time_per_apt_integration'
     )
-    integrations_per_exposure = int(np.ceil(
-        required_integrations / float(exposures_per_dither)
-    ))
-    scheduled_integrations = (
-        exposures_per_dither * integrations_per_exposure
-    )
-    stripe_elapsed_time = (
-        timing['Time/Integration incl reset (sec)'] / float(nstripes)
-    )
-
-    return {
-        'cycles': cycles,
-        'required_integrations': required_integrations,
-        'scheduled_integrations': scheduled_integrations,
-        'exposures_per_dither': exposures_per_dither,
-        'integrations_per_exposure': integrations_per_exposure,
-        'stripe_elapsed_time': stripe_elapsed_time,
-        'exposure_duration': scheduled_integrations * stripe_elapsed_time,
-    }
+    return parameters
 
 
 def nirspec_prism_exposure_warning(timing):
@@ -2244,6 +2330,30 @@ def nirspec_prism_exposure_warning(timing):
     )
 
 
+def update_apt_timing(
+        timing,
+        integration_multiplier=1,
+        max_frames_per_exposure=None,
+        frames_per_integration=None):
+    """Add universal APT exposure-splitting values to a timing dictionary."""
+    apt_parameters = apt_exposure_parameters(
+        timing,
+        integration_multiplier=integration_multiplier,
+        max_frames_per_exposure=max_frames_per_exposure,
+        frames_per_integration=frames_per_integration,
+    )
+    timing.update({
+        'APT: Exposures/Dith': apt_parameters['exposures_per_dither'],
+        'APT: Num Integrations per Exposure': (
+            apt_parameters['integrations_per_exposure']
+        ),
+        'APT: Num Integrations per Occultation': (
+            apt_parameters['scheduled_integrations']
+        ),
+    })
+    return timing
+
+
 def update_nirspec_prism_apt_timing(timing):
     """Add NIRSpec PRISM multistripe APT values to a timing dictionary.
 
@@ -2261,17 +2371,12 @@ def update_nirspec_prism_apt_timing(timing):
     dict
         The updated timing dictionary.
     """
-    apt_parameters = nirspec_prism_apt_parameters(timing)
-    timing.update({
-        'Num Multistripe Cycles per Occultation': apt_parameters['cycles'],
-        'APT: Exposures/Dith': apt_parameters['exposures_per_dither'],
-        'APT: Num Integrations per Exposure': (
-            apt_parameters['integrations_per_exposure']
-        ),
-        'APT: Num Integrations per Occultation': (
-            apt_parameters['scheduled_integrations']
-        ),
-    })
+    nstripes = int(timing.get('Num Superstripes', 1) or 1)
+    timing['Num Multistripe Cycles per Occultation'] = int(
+        timing['Num Integrations In Transit']
+        + timing['Num Integrations Out of Transit']
+    )
+    update_apt_timing(timing, integration_multiplier=nstripes)
     return timing
 
 
@@ -2376,15 +2481,18 @@ def build_timing_display_div(out, timing):
     ])
     if is_nirspec_prism_multistripe:
         apt_parameters = nirspec_prism_apt_parameters(timing)
-        apt_rows.extend([
-            ('Exposures/Dith', apt_parameters['exposures_per_dither']),
-            ('Integrations/Exp', apt_parameters['integrations_per_exposure']),
-        ])
+        exposures_per_dither = apt_parameters['exposures_per_dither']
+        integrations_per_exposure = apt_parameters['integrations_per_exposure']
     else:
-        apt_rows.append((
-            'Integrations per Occultation',
-            timing['APT: Num Integrations per Occultation']
-        ))
+        exposures_per_dither = timing.get('APT: Exposures/Dith', 1)
+        integrations_per_exposure = timing.get(
+            'APT: Num Integrations per Exposure',
+            timing['APT: Num Integrations per Occultation'],
+        )
+    apt_rows.extend([
+        ('Exposures/Dith', exposures_per_dither),
+        ('Integrations/Exp', integrations_per_exposure),
+    ])
 
     calculation_rows = [
         ('Transit Duration (hr)', timing['Transit Duration']),

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -17,6 +17,7 @@ from pandexo.engine.jwst import (
     _nircam_dhs_optimization_configs,
     _table_html,
     add_warnings,
+    apt_exposure_parameters,
     build_timing_display_div,
     compute_timing,
     estimate_dhs_data_excess,
@@ -27,6 +28,7 @@ from pandexo.engine.jwst import (
     nirspec_prism_exposure_warning,
     select_calculation,
     update_nirspec_prism_apt_timing,
+    update_apt_timing,
     update_timing_measurement_time,
     validate_miri_lrs_subarray,
 )
@@ -656,7 +658,8 @@ def test_multistripe_timing_display_uses_apt_and_calculation_tables():
     assert "Calculation Details" not in html
     assert html.count("<table") == 2
     assert "Groups per Integration" in html
-    assert "Integrations per Occultation" in html
+    assert "Exposures/Dith" in html
+    assert "Integrations/Exp" in html
     assert "Number of Stripes" in html
     assert "Elapsed Time per Full Multistripe Cycle incl. Reset (sec)" in html
     assert "Elapsed Time per APT Stripe Integration" not in html
@@ -732,6 +735,65 @@ def test_nirspec_prism_apt_parameters_round_up_without_exceeding_limit():
     assert parameters["integrations_per_exposure"] == 43691
     assert parameters["integrations_per_exposure"] <= 65535
     assert parameters["scheduled_integrations"] == 131073
+
+
+def test_apt_integration_limit_is_applied_to_standard_modes():
+    timing = {
+        "Num Integrations In Transit": 40000,
+        "Num Integrations Out of Transit": 40000,
+        "Time/Integration incl reset (sec)": 2.0,
+    }
+
+    update_apt_timing(timing)
+
+    assert timing["APT: Exposures/Dith"] == 2
+    assert timing["APT: Num Integrations per Exposure"] == 40000
+    assert timing["APT: Num Integrations per Occultation"] == 80000
+
+
+def test_frame_limit_can_require_additional_exposures():
+    timing = {
+        "Num Integrations In Transit": 25000,
+        "Num Integrations Out of Transit": 25000,
+        "Time/Integration incl reset (sec)": 10.0,
+    }
+
+    parameters = apt_exposure_parameters(
+        timing,
+        max_frames_per_exposure=196608,
+        frames_per_integration=10,
+    )
+
+    assert parameters["max_integrations_per_exposure"] == 19660
+    assert parameters["exposures_per_dither"] == 3
+    assert parameters["integrations_per_exposure"] == 16667
+    assert parameters["integrations_per_exposure"] * 10 <= 196608
+
+
+def test_niriss_soss_groups_are_limited_to_30():
+    from pandexo.engine.jwst import max_ngroup
+
+    assert max_ngroup["niriss"] == 30
+
+
+def test_user_specified_groups_are_capped_at_instrument_limit():
+    timing, flags = compute_timing(
+        {
+            "ngroup": 31,
+            "tframe": 2.0,
+            "nframe": 1,
+            "mingroups": 2,
+            "nskip": 0,
+            "nsuperstripe": 1,
+        },
+        transit_duration=240.0,
+        expfact_out=1.0,
+        noccultations=1,
+        max_ngroup_instrument=30,
+    )
+
+    assert timing["APT: Num Groups per Integration"] == 30
+    assert "User-specified NGROUPS (31) exceeds the maximum (30)" in flags["flag_high"]
 
 
 def test_nirspec_prism_timing_display_uses_apt_stripe_integrations():

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -23,7 +23,10 @@ from pandexo.engine.jwst import (
     estimate_nircam_data_excess,
     nircam_dhs_no_ta_overhead,
     nircam_no_ta_overhead,
+    nirspec_prism_apt_parameters,
+    nirspec_prism_exposure_warning,
     select_calculation,
+    update_nirspec_prism_apt_timing,
     update_timing_measurement_time,
     validate_miri_lrs_subarray,
 )
@@ -220,7 +223,9 @@ def _timing(nsuperstripe, ngroup=3, mingroups=2):
     return timing
 
 
-def _timing_with_pandeia_cycle(nsuperstripe, exposure_time_per_int, ngroup=3):
+def _timing_with_pandeia_cycle(
+        nsuperstripe, exposure_time_per_int, ngroup=3,
+        transit_duration=48.0):
     timing, _ = compute_timing(
         {
             "ngroup": ngroup,
@@ -232,7 +237,7 @@ def _timing_with_pandeia_cycle(nsuperstripe, exposure_time_per_int, ngroup=3):
             "exposure_time_per_int": exposure_time_per_int,
             "exposure_time_ngroup": ngroup,
         },
-        transit_duration=48.0,
+        transit_duration=transit_duration,
         expfact_out=1.0,
         noccultations=1,
         max_ngroup_instrument=65536,
@@ -424,18 +429,21 @@ def test_skipped_frames_contribute_to_elapsed_integration_time():
     assert timing["Measurement Time per Integration (sec)"] == pytest.approx(12.0)
 
 
-def test_multistripe_effective_time_is_divided_by_nsuperstripe():
+def test_multistripe_cycles_are_not_divided_by_nsuperstripe():
     timing = _timing(nsuperstripe=4)
 
-    assert timing["Effective Integrations In Transit"] == pytest.approx(
-        timing["Num Integrations In Transit"] / 4.0
+    assert (
+        timing["Effective Integrations In Transit"]
+        == timing["Num Integrations In Transit"]
     )
-    assert timing["Effective Integrations Out of Transit"] == pytest.approx(
-        timing["Num Integrations Out of Transit"] / 4.0
+    assert (
+        timing["Effective Integrations Out of Transit"]
+        == timing["Num Integrations Out of Transit"]
     )
     assert timing["On Source Time In Transit"] == pytest.approx(
-        timing["Effective Integrations In Transit"]
+        timing["Num Integrations In Transit"]
         * timing["Measurement Time per Integration (sec)"]
+        / timing["Num Superstripes"]
     )
     assert timing["Effective On Source Time In Transit"] == pytest.approx(
         timing["On Source Time In Transit"]
@@ -463,10 +471,10 @@ def test_pandeia_measurement_time_update_controls_on_source_metadata():
 
     assert timing["Measurement Time per Integration (sec)"] == 32.0
     assert timing["On Source Time In Transit"] == pytest.approx(
-        timing["Effective Integrations In Transit"] * 32.0
+        timing["Num Integrations In Transit"] * 32.0 / 4.0
     )
     assert timing["Effective On Source Time In Transit"] == pytest.approx(
-        timing["Effective Integrations In Transit"] * 32.0
+        timing["On Source Time In Transit"]
     )
 
 
@@ -479,7 +487,7 @@ def test_multistripe_timing_uses_pandeia_full_cycle_clock_for_real_integrations(
 
     assert timing["Time/Integration incl reset (sec)"] == pytest.approx(40.0)
     assert timing["Num Integrations In Transit"] == 2
-    assert timing["Effective Integrations In Transit"] == pytest.approx(0.5)
+    assert timing["Effective Integrations In Transit"] == 2
     assert timing["Measurement Time per Integration (sec)"] == pytest.approx(16.0)
     assert timing["On Source Time In Transit"] == pytest.approx(8.0)
 
@@ -530,7 +538,8 @@ def test_soss_sub17stripe_clock_time_matches_pandeia_full_cycle():
         "Num Superstripes"
     ] == pytest.approx(0.43148)
     assert timing["Num Integrations In Transit"] == 147
-    assert timing["Effective Integrations In Transit"] == pytest.approx(147 / 120.0)
+    assert timing["Effective Integrations In Transit"] == 147
+    assert timing["On Source Time In Transit"] == pytest.approx(147 * 0.43148)
 
 
 def test_soss_multistripe_efficiency_uses_per_stripe_science_time():
@@ -649,7 +658,8 @@ def test_multistripe_timing_display_uses_apt_and_calculation_tables():
     assert "Groups per Integration" in html
     assert "Integrations per Occultation" in html
     assert "Number of Stripes" in html
-    assert "Elapsed Time per APT Integration incl. Reset (sec)" in html
+    assert "Elapsed Time per Full Multistripe Cycle incl. Reset (sec)" in html
+    assert "Elapsed Time per APT Stripe Integration" not in html
     assert "Science Time per Full Multistripe Cycle excl. Reset (sec)" in html
     assert "Science Time per Stripe excl. Reset (sec)" in html
     assert "Effective Per-Wavelength" not in html
@@ -669,6 +679,127 @@ def test_timing_display_includes_estimated_dhs_data_excess():
     assert "4.3 (Verify using APT)" in html
     assert "4.26" not in html
     assert "Assumed No-TA Scheduling + Slew Overhead (sec)" in html
+
+
+def test_nirspec_prism_apt_parameters_match_published_multistripe_example():
+    timing = {
+        "Num Superstripes": 8,
+        "Num Integrations In Transit": 15405,
+        "Num Integrations Out of Transit": 15405,
+        "Time/Integration incl reset (sec)": 1.09312,
+    }
+
+    parameters = nirspec_prism_apt_parameters(timing)
+
+    assert parameters["cycles"] == 30810
+    assert parameters["required_integrations"] == 246480
+    assert parameters["exposures_per_dither"] == 4
+    assert parameters["integrations_per_exposure"] == 61620
+    assert parameters["scheduled_integrations"] == 246480
+    assert parameters["stripe_elapsed_time"] == pytest.approx(0.13664)
+    assert parameters["exposure_duration"] == pytest.approx(33679.0272)
+
+
+def test_nirspec_prism_apt_values_are_available_to_offline_outputs():
+    timing = {
+        "Num Superstripes": 8,
+        "Num Integrations In Transit": 15405,
+        "Num Integrations Out of Transit": 15405,
+        "Time/Integration incl reset (sec)": 1.09312,
+        "APT: Num Integrations per Occultation": 30810,
+    }
+
+    update_nirspec_prism_apt_timing(timing)
+
+    assert timing["Num Multistripe Cycles per Occultation"] == 30810
+    assert timing["APT: Exposures/Dith"] == 4
+    assert timing["APT: Num Integrations per Exposure"] == 61620
+    assert timing["APT: Num Integrations per Occultation"] == 246480
+
+
+def test_nirspec_prism_apt_parameters_round_up_without_exceeding_limit():
+    timing = {
+        "Num Superstripes": 8,
+        "Num Integrations In Transit": 8192,
+        "Num Integrations Out of Transit": 8192,
+        "Time/Integration incl reset (sec)": 1.09312,
+    }
+
+    parameters = nirspec_prism_apt_parameters(timing)
+
+    assert parameters["required_integrations"] == 131072
+    assert parameters["exposures_per_dither"] == 3
+    assert parameters["integrations_per_exposure"] == 43691
+    assert parameters["integrations_per_exposure"] <= 65535
+    assert parameters["scheduled_integrations"] == 131073
+
+
+def test_nirspec_prism_timing_display_uses_apt_stripe_integrations():
+    timing = _timing_with_pandeia_cycle(
+        nsuperstripe=8,
+        exposure_time_per_int=1.09312,
+        ngroup=3,
+    )
+    timing.update({
+        "Num Integrations In Transit": 15405,
+        "Num Integrations Out of Transit": 15405,
+        "Effective Integrations In Transit": 15405,
+        "Effective Integrations Out of Transit": 15405,
+        "APT: Num Integrations per Occultation": 30810,
+    })
+    apt_div, calculation_div = build_timing_display_div(
+        _pandeia_out(
+            instrument={
+                "instrument": "nirspec",
+                "mode": "bots",
+                "filter": "clear",
+                "aperture": "s1600a1",
+                "disperser": "prism",
+            },
+            detector={
+                "subarray": "s64m8_prm",
+                "readout_pattern": "nrsrapid",
+            },
+        ),
+        timing,
+    )
+    apt_html = apt_div.decode()
+    calculation_html = calculation_div.decode()
+
+    assert "Exposures/Dith" in apt_html
+    assert "<td>4</td>" in apt_html
+    assert "Integrations/Exp" in apt_html
+    assert "<td>61620</td>" in apt_html
+    assert "Integrations per Occultation" not in apt_html
+    assert "Elapsed Time per Full Multistripe Cycle incl. Reset (sec)" in calculation_html
+    assert "<td>1.093120</td>" in calculation_html
+    assert "Elapsed Time per APT Stripe Integration incl. Reset (sec)" in calculation_html
+    assert "<td>0.136640</td>" in calculation_html
+
+
+def test_nirspec_multistripe_hga_warning_is_included_when_relevant():
+    long_timing = {
+        "Num Superstripes": 8,
+        "Num Integrations In Transit": 15405,
+        "Num Integrations Out of Transit": 15405,
+        "Time/Integration incl reset (sec)": 1.09312,
+    }
+    warning = nirspec_prism_exposure_warning(long_timing)
+    warnings = add_warnings(
+        {"warnings": {}},
+        _timing(nsuperstripe=8),
+        sat_level=0.8,
+        flags={
+            "flag_default": "All good",
+            "flag_high": "All good",
+            "flag_min_nint": "All good",
+            "flag_hga_repoint": warning,
+        },
+        instrument="nirspec",
+    )
+
+    assert warnings["Exposure Duration?"].startswith("APT will warn")
+    assert "NIRSpec BOTS permits longer exposures" in warnings["Exposure Duration?"]
 
 
 def test_view_template_owns_timing_table_headings():
@@ -912,16 +1043,31 @@ def test_miri_lrs_timing_display_uses_dither_not_filter_and_uppercase_readout():
     assert "<td>fastr1</td>" not in html
 
 
-def test_slope_uncertainty_increases_by_sqrt_nsuperstripe():
+def test_slope_noise_uses_real_multistripe_cycle_count():
     nsuperstripe = 9
     normal = _slope_result(_timing(nsuperstripe=1))
     multistripe = _slope_result(_timing(nsuperstripe=nsuperstripe))
 
     ratio = _fractional_uncertainty(multistripe) / _fractional_uncertainty(normal)
 
-    assert ratio == pytest.approx(np.sqrt(nsuperstripe))
+    assert ratio == pytest.approx(1.0)
     assert multistripe["on_source_in"] == pytest.approx(normal["on_source_in"] / nsuperstripe)
-    assert multistripe["nint_in"] == pytest.approx(normal["nint_in"] / nsuperstripe)
+    assert multistripe["nint_in"] == normal["nint_in"]
+
+
+def test_fixed_wall_time_retains_multistripe_cycle_penalty():
+    normal = _slope_result(_timing_with_pandeia_cycle(
+        1, 10.0, transit_duration=270.0
+    ))
+    multistripe = _slope_result(_timing_with_pandeia_cycle(
+        9, 90.0, transit_duration=270.0
+    ))
+
+    ratio = _fractional_uncertainty(multistripe) / _fractional_uncertainty(normal)
+
+    assert normal["nint_in"] == 27
+    assert multistripe["nint_in"] == 3
+    assert ratio == pytest.approx(3.0)
 
 
 def test_single_group_fml_path_stays_finite():
@@ -1088,6 +1234,31 @@ def test_pandeia_nirspec_prism_multistripe_exposes_superstripes(
     assert select_calculation("um", exp_pars.nsuperstripe) == "slope method"
     assert timing["Num Superstripes"] == expected_nsuperstripe
     assert timing["Observing Efficiency (%)"] < 100.0
+
+
+def test_pandeia_nirspec_multistripe_nint_counts_complete_cycles():
+    _skip_if_pandeia_refdata_invalid()
+    from pandeia.engine.instrument_factory import InstrumentFactory
+
+    one_cycle_config = _nirspec_prism_config("s64m8_prm")
+    one_cycle_config["detector"]["nint"] = 1
+    one_cycle_config["detector"]["nexp"] = 1
+    eight_cycle_config = deepcopy(one_cycle_config)
+    eight_cycle_config["detector"]["nint"] = 8
+
+    one_cycle = InstrumentFactory(
+        config=one_cycle_config
+    ).the_detector.exposure_spec
+    eight_cycles = InstrumentFactory(
+        config=eight_cycle_config
+    ).the_detector.exposure_spec
+
+    assert one_cycle.nsuperstripe == 8
+    assert one_cycle.nramps == 1
+    assert eight_cycles.nramps == 8
+    assert eight_cycles.measurement_time == pytest.approx(
+        8 * one_cycle.measurement_time
+    )
 
 
 def test_pandeia_miri_lrs_slit_supports_subslit():


### PR DESCRIPTION
## Summary

This PR corrects PandExo timing and noise scaling for NIRSpec PRISM multistripe observations and makes the reported APT inputs obey current exposure limits.

### NIRSpec PRISM multistripe timing

- Treat each Pandeia integration as one complete cycle through all stripes.
- Use the real multistripe cycle count for noise scaling.
- Retain the per-stripe science time when calculating the signal collected at each wavelength.
- Convert full-cycle counts to stripe-level APT integrations.
- Split stripe integrations across multiple exposures when required.
- Show full-cycle and per-stripe timing values with clearer labels.
- Warn when a long BOTS exposure may be affected by an HGA repoint.

### APT limits

- Enforce the universal maximum of 65,535 integrations per exposure.
- Enforce the universal maximum of 196,608 frames per exposure.
- Limit NIRISS/SOSS to 30 groups per integration.
- Cap invalid optimized or user-specified group counts and report the adjustment.
- Report `Exposures/Dith` and `Integrations/Exp` in the APT inputs table.

## Validation

- Full test suite run with the 2026.7 release-candidate Pandeia engine and reference data.
- **163 tests passed.**