### PR TITLE
Quantize total observing time for multistripe timing and enforce exposure limits

### DIFF
--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -725,7 +725,8 @@ def compute_full_sim(dictinput,verbose=False):
         #convert to seconds, then remove quantity and convert back to float 
         transit_duration = float((pandexo_input['planet']['transit_duration']*u.Unit(pandexo_input['planet']['td_unit'])).to(u.second)/u.second)
 
-    #amount of exposure time out-of-occultation, as a fraction of in-occ time 
+    #amount of exposure time out-of-occultation, as a fraction of in-occ time
+    total_observing_time = None
     try:
         expfact_out = pandexo_input['observation']['fraction'] 
         log("WARNING: key input fraction has been replaced with new 'baseline option'. See notebook example")
@@ -735,9 +736,19 @@ def compute_full_sim(dictinput,verbose=False):
         if pandexo_input['observation']['baseline_unit'] =='frac':
             expfact_out = pandexo_input['observation']['baseline'] 
         elif pandexo_input['observation']['baseline_unit'] =='total':
-            expfact_out = transit_duration/( pandexo_input['observation']['baseline'] - transit_duration)
+            total_observing_time = float(
+                pandexo_input['observation']['baseline']
+            )
+            expfact_out = transit_duration/(
+                total_observing_time - transit_duration
+            )
         elif pandexo_input['observation']['baseline_unit'] =='total_hrs':
-            expfact_out = transit_duration/( pandexo_input['observation']['baseline']*3600.0 - transit_duration)
+            total_observing_time = float(
+                pandexo_input['observation']['baseline']
+            ) * 3600.0
+            expfact_out = transit_duration/(
+                total_observing_time - transit_duration
+            )
         else: 
             raise Exception("Wrong units for baseine: either 'frac' or 'total' or 'total_hrs' accepted")
 
@@ -795,7 +806,10 @@ def compute_full_sim(dictinput,verbose=False):
 
     #calculate all timing info
     max_ngroup_instrument = max_ngroup[str(instrument).lower()]
-    timing, flags = compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instrument)
+    timing, flags = compute_timing(
+        m, transit_duration, expfact_out, noccultations,
+        max_ngroup_instrument, total_observing_time=total_observing_time,
+    )
     if optimize_nircam_readout:
         selected = None
         rejected_readouts = []
@@ -834,6 +848,7 @@ def compute_full_sim(dictinput,verbose=False):
                 expfact_out,
                 noccultations,
                 max_ngroup_instrument,
+                total_observing_time=total_observing_time,
             )
             allocation_overhead = nircam_no_ta_overhead(
                 candidate_exposure.tframe
@@ -1283,7 +1298,9 @@ def compute_maxexptime_per_int(pandeia_input, sat_level):
     
     return maxexptime_per_int
         
-def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instrument=65536.0):
+def compute_timing(
+        m, transit_duration, expfact_out, noccultations,
+        max_ngroup_instrument=65536.0, total_observing_time=None):
     """Computes all timing info for observation
     
     Computes all JWST specific timing info for observation including. Some pertinent 
@@ -1304,6 +1321,14 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
         fraction of time spent in transit versus out of transit 
     noccultations : int 
         number of transits 
+    max_ngroup_instrument : int or float, optional
+        Maximum groups per integration for the selected instrument.
+    total_observing_time : float, optional
+        Requested total in- plus out-of-transit observing time in seconds.
+        When supplied, the total number of integrations is quantized once and
+        the out-of-transit count is the remainder after assigning the
+        in-transit integrations. When omitted, ``expfact_out`` determines the
+        out-of-transit count.
     
     Returns
     ------- 
@@ -1328,6 +1353,11 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
     nsuperstripe = int(m.get("nsuperstripe", 1) or 1)
     if nsuperstripe < 1:
         nsuperstripe = 1
+    def _ceil_count(value):
+        # Remove a one-ULP floating-point overshoot at exact integration
+        # boundaries without treating a genuinely longer duration as exact.
+        return int(np.ceil(np.nextafter(float(value), -np.inf)))
+
     def _clocktime_per_int(ngroups):
         if (m.get("exposure_time_per_int") is not None and
                 ngroups == m.get("exposure_time_ngroup")):
@@ -1358,8 +1388,14 @@ def compute_timing(m,transit_duration,expfact_out,noccultations,max_ngroup_instr
         clocktime_per_int = _clocktime_per_int(ngroups)
         eff = measurement_time_per_int/float(nsuperstripe)/clocktime_per_int
         nint_per_occultation = transit_duration/clocktime_per_int
-        nint_in = np.ceil(nint_per_occultation)
-        nint_out = np.ceil(nint_in/expfact_out)
+        nint_in = _ceil_count(nint_per_occultation)
+        if total_observing_time is None:
+            nint_out = _ceil_count(nint_in/expfact_out)
+        else:
+            total_nint = _ceil_count(
+                total_observing_time/clocktime_per_int
+            )
+            nint_out = max(0, total_nint - nint_in)
 
         return {
             "frame_zero_dead": frame_zero_dead,
@@ -2223,6 +2259,11 @@ def apt_exposure_parameters(
             )
         effective_limit = min(effective_limit, frame_limited_integrations)
 
+    if integration_multiplier > effective_limit:
+        raise ValueError(
+            'one complete multistripe cycle exceeds the per-exposure limit'
+        )
+
     integrations = int(
         timing['Num Integrations In Transit']
         + timing['Num Integrations Out of Transit']
@@ -2232,9 +2273,21 @@ def apt_exposure_parameters(
         1,
         int(np.ceil(required_integrations / float(effective_limit))),
     )
-    integrations_per_exposure = int(np.ceil(
-        required_integrations / float(exposures_per_dither)
-    ))
+    while True:
+        minimum_integrations = int(np.ceil(
+            required_integrations / float(exposures_per_dither)
+        ))
+        # End every exposure on a complete multistripe cycle so that each
+        # stripe receives the same number of integrations in every exposure.
+        per_exposure_multiple = integration_multiplier
+        integrations_per_exposure = int(
+            np.ceil(
+                minimum_integrations / float(per_exposure_multiple)
+            ) * per_exposure_multiple
+        )
+        if integrations_per_exposure <= effective_limit:
+            break
+        exposures_per_dither += 1
     scheduled_integrations = exposures_per_dither * integrations_per_exposure
     elapsed_time_per_apt_integration = (
         timing['Time/Integration incl reset (sec)']

--- a/tests/test_jwst_timing_noise.py
+++ b/tests/test_jwst_timing_noise.py
@@ -684,7 +684,40 @@ def test_timing_display_includes_estimated_dhs_data_excess():
     assert "Assumed No-TA Scheduling + Slew Overhead (sec)" in html
 
 
-def test_nirspec_prism_apt_parameters_match_published_multistripe_example():
+def test_total_observing_time_is_quantized_once_for_multistripe_timing():
+    cycle_time = 1.09312
+    requested_cycles = 30810
+    total_observing_time = requested_cycles * cycle_time
+    transit_duration = 3.816 * 3600.0
+
+    timing, _ = compute_timing(
+        {
+            "ngroup": 3,
+            "tframe": 0.02904,
+            "nframe": 1,
+            "mingroups": 2,
+            "nskip": 0,
+            "nsuperstripe": 8,
+            "exposure_time_per_int": cycle_time,
+            "exposure_time_ngroup": 3,
+        },
+        transit_duration=transit_duration,
+        expfact_out=transit_duration / (
+            total_observing_time - transit_duration
+        ),
+        noccultations=1,
+        total_observing_time=total_observing_time,
+    )
+
+    assert timing["Num Integrations In Transit"] == 12568
+    assert timing["Num Integrations Out of Transit"] == 18242
+    assert timing["APT: Num Integrations per Occultation"] == requested_cycles
+    assert timing["Transit+Baseline, no overhead (hrs)"] == pytest.approx(
+        total_observing_time / 3600.0
+    )
+
+
+def test_nirspec_prism_apt_parameters_pad_published_example_to_full_cycles():
     timing = {
         "Num Superstripes": 8,
         "Num Integrations In Transit": 15405,
@@ -697,10 +730,11 @@ def test_nirspec_prism_apt_parameters_match_published_multistripe_example():
     assert parameters["cycles"] == 30810
     assert parameters["required_integrations"] == 246480
     assert parameters["exposures_per_dither"] == 4
-    assert parameters["integrations_per_exposure"] == 61620
-    assert parameters["scheduled_integrations"] == 246480
+    assert parameters["integrations_per_exposure"] == 61624
+    assert parameters["scheduled_integrations"] == 246496
+    assert parameters["integrations_per_exposure"] % 8 == 0
     assert parameters["stripe_elapsed_time"] == pytest.approx(0.13664)
-    assert parameters["exposure_duration"] == pytest.approx(33679.0272)
+    assert parameters["exposure_duration"] == pytest.approx(33681.21344)
 
 
 def test_nirspec_prism_apt_values_are_available_to_offline_outputs():
@@ -716,8 +750,8 @@ def test_nirspec_prism_apt_values_are_available_to_offline_outputs():
 
     assert timing["Num Multistripe Cycles per Occultation"] == 30810
     assert timing["APT: Exposures/Dith"] == 4
-    assert timing["APT: Num Integrations per Exposure"] == 61620
-    assert timing["APT: Num Integrations per Occultation"] == 246480
+    assert timing["APT: Num Integrations per Exposure"] == 61624
+    assert timing["APT: Num Integrations per Occultation"] == 246496
 
 
 def test_nirspec_prism_apt_parameters_round_up_without_exceeding_limit():
@@ -732,9 +766,10 @@ def test_nirspec_prism_apt_parameters_round_up_without_exceeding_limit():
 
     assert parameters["required_integrations"] == 131072
     assert parameters["exposures_per_dither"] == 3
-    assert parameters["integrations_per_exposure"] == 43691
+    assert parameters["integrations_per_exposure"] == 43696
     assert parameters["integrations_per_exposure"] <= 65535
-    assert parameters["scheduled_integrations"] == 131073
+    assert parameters["integrations_per_exposure"] % 8 == 0
+    assert parameters["scheduled_integrations"] == 131088
 
 
 def test_apt_integration_limit_is_applied_to_standard_modes():
@@ -768,6 +803,22 @@ def test_frame_limit_can_require_additional_exposures():
     assert parameters["exposures_per_dither"] == 3
     assert parameters["integrations_per_exposure"] == 16667
     assert parameters["integrations_per_exposure"] * 10 <= 196608
+
+
+def test_exposure_limit_must_fit_one_complete_multistripe_cycle():
+    timing = {
+        "Num Integrations In Transit": 1,
+        "Num Integrations Out of Transit": 1,
+        "Time/Integration incl reset (sec)": 8.0,
+    }
+
+    with pytest.raises(
+            ValueError, match="one complete multistripe cycle"):
+        apt_exposure_parameters(
+            timing,
+            integration_multiplier=8,
+            max_integrations_per_exposure=7,
+        )
 
 
 def test_niriss_soss_groups_are_limited_to_30():
@@ -831,7 +882,7 @@ def test_nirspec_prism_timing_display_uses_apt_stripe_integrations():
     assert "Exposures/Dith" in apt_html
     assert "<td>4</td>" in apt_html
     assert "Integrations/Exp" in apt_html
-    assert "<td>61620</td>" in apt_html
+    assert "<td>61624</td>" in apt_html
     assert "Integrations per Occultation" not in apt_html
     assert "Elapsed Time per Full Multistripe Cycle incl. Reset (sec)" in calculation_html
     assert "<td>1.093120</td>" in calculation_html


### PR DESCRIPTION
## Summary

Fix integration rounding for total-duration observations and ensure NIRSpec PRISM multistripe exposures provide even wavelength coverage.

## Changes

- Quantize total observing time once instead of independently rounding and rescaling the in- and out-of-transit integration counts.
- Allocate out-of-transit integrations from the remaining total integration count.
- Require `Integrations/Exp` to be an integer multiple of the number of stripes for NIRSpec.
- Pad each exposure to a complete multistripe cycle without exceeding APT limits for NIRSpec.
- Raise a clear error if one complete multistripe cycle cannot fit within an exposure for NIRSpec.
- Avoid one-ULP floating-point errors at exact integration boundaries.

For the JDox eight-stripe example, PandExo recommends `61,624` rather than `61,620` integrations per exposure. The additional four integrations ensure that each exposure ends on a complete eight-stripe cycle.

## Testing

- Added regression coverage for total-duration quantization.
- Added tests for complete multistripe cycles per exposure.
- Added coverage for impossible per-exposure limits.
- Full suite passes with the Pandeia release candidate: `189 passed`.