### PR TITLE
Preserve proxy prefixes in calculation redirects

### DIFF
--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -190,7 +190,10 @@ class Application(tornado.web.Application):
             (r"/about", AboutHandler),
             (r"/dashboard", DashboardHandler),
             (r"/dashboardhst", DashboardHSTHandler),
-            (r"/calculation/?", tornado.web.RedirectHandler, {"url": "/dashboard"}),
+            # Relative redirects preserve a reverse-proxy prefix such as
+            # ``/pandexo`` while still working from the local application root.
+            (r"/calculation", tornado.web.RedirectHandler, {"url": "dashboard"}),
+            (r"/calculation/", tornado.web.RedirectHandler, {"url": "../dashboard"}),
             (r"/tables", TablesHandler),
             (r"/helpfulplots", HelpfulPlotsHandler),
             (r"/calculation/new", CalculationNewHandler),

--- a/tests/test_run_online_routes.py
+++ b/tests/test_run_online_routes.py
@@ -1,4 +1,5 @@
 import tornado.testing
+from urllib.parse import urljoin
 
 from pandexo.engine.run_online import Application
 
@@ -8,8 +9,17 @@ class TestCalculationRedirect(tornado.testing.AsyncHTTPTestCase):
         return Application()
 
     def test_calculation_redirects_to_dashboard(self):
-        for path in ("/calculation", "/calculation/"):
+        for path, location in (
+            ("/calculation", "dashboard"),
+            ("/calculation/", "../dashboard"),
+        ):
             response = self.fetch(path, follow_redirects=False)
 
             assert response.code == 301
-            assert response.headers["Location"] == "/dashboard"
+            assert response.headers["Location"] == location
+            assert (
+                urljoin(
+                    f"https://exoctk-dev.stsci.edu/pandexo{path}", location
+                )
+                == "https://exoctk-dev.stsci.edu/pandexo/dashboard"
+            )


### PR DESCRIPTION
Redirect both /calculation variants with relative URLs so deployments under /pandexo reach the dashboard without breaking local Docker URLs.

Add route coverage for trailing-slash and reverse-proxy resolution.