### PR TITLE
Validate JWST website instrument configurations

### DIFF
--- a/pandexo/engine/jwst.py
+++ b/pandexo/engine/jwst.py
@@ -28,6 +28,7 @@ NIRSPEC_PRISM_MULTISTRIPE_MAX_WAVELENGTHS = {
     "s64m8_prm": 4.98,
     "s32m16_prm": 4.66,
 }
+NIRSPEC_PRISM_CLEAR_UNSUPPORTED_SUBARRAYS = ("sub1024a",)
 APT_MAX_INTEGRATIONS_PER_EXPOSURE = 65535
 MAX_FRAMES_PER_EXPOSURE = 196608
 NIRSPEC_HGA_REPOINT_WARNING_SECONDS = 10000.0
@@ -333,6 +334,28 @@ def validate_miri_lrs_subarray(conf):
         raise ValueError(
             f"MIRI LRS {mode.upper()} supports only these subarrays: "
             f"{allowed_display}. Got {subarray.upper()}."
+        )
+
+
+def validate_nirspec_prism_subarray(conf):
+    """Validate NIRSpec PRISM/CLEAR subarrays before calling Pandeia."""
+    instrument = conf.get("instrument", {})
+    detector = conf.get("detector", {})
+    if str(instrument.get("instrument", "")).lower() != "nirspec":
+        return
+
+    disperser = str(instrument.get("disperser", "")).lower()
+    filt = str(instrument.get("filter", "")).lower()
+    subarray = str(detector.get("subarray", "")).lower()
+    if (
+        disperser == "prism"
+        and filt == "clear"
+        and subarray in NIRSPEC_PRISM_CLEAR_UNSUPPORTED_SUBARRAYS
+    ):
+        raise ValueError(
+            "NIRSpec PRISM/CLEAR does not support the SUB1024A subarray. "
+            "Choose SUB512, SUB1024B, SUB2048, or a PRISM multistripe "
+            "subarray."
         )
 
 
@@ -678,6 +701,7 @@ def compute_full_sim(dictinput,verbose=False):
     instrument = pandeia_input['configuration']['instrument']['instrument']
     conf = pandeia_input['configuration']
     validate_miri_lrs_subarray(conf)
+    validate_nirspec_prism_subarray(conf)
 
     #now fix DHS #of spectra depending on the subarray
     is_dhs = 'dhs' in conf['instrument']['aperture']

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -23,7 +23,7 @@ from astroquery.simbad import Simbad
 import astropy.units as u
 
 from .pandexo import wrapper
-from .jwst import validate_nirspec_prism_subarray
+from .jwst import validate_miri_lrs_subarray, validate_nirspec_prism_subarray
 from .utils.plotters import create_component_jwst, create_component_hst
 from .logs import jwst_log, hst_log
 from .exomast import async_get_target_data
@@ -51,6 +51,89 @@ NIRSPEC_PRISM_MULTISTRIPE_SUBARRAYS = (
     "s64m8_prm",
     "s32m16_prm",
 )
+NIRSPEC_WEB_MODES = (
+    "g140mf070lp", "g140hf070lp", "g140mf100lp", "g140hf100lp",
+    "g235mf170lp", "g235hf170lp", "g395mf290lp", "g395hf290lp",
+    "prismclear",
+)
+NIRSPEC_STANDARD_SUBARRAYS = ("sub2048", "sub1024a", "sub1024b", "sub512")
+NIRCAM_WEB_FILTERS = ("f322w2", "f444w")
+NIRCAM_WEB_SUBARRAYS = (
+    "subgrism64", "subgrism128", "subgrism256",
+    "subgrism64 (noutputs=1)", "subgrism128 (noutputs=1)",
+    "subgrism256 (noutputs=1)",
+)
+NIRCAM_WEB_READOUTS = (
+    "optimize", "rapid", "bright1", "bright2", "shallow2", "shallow4",
+    "medium2", "medium8", "mediumdeep2", "mediumdeep8", "deep2", "deep8",
+)
+NIRCAM_DHS_WEB_FILTERS = ("f070w", "f090w", "f115w", "f150w2", "f200w")
+NIRCAM_DHS_WEB_SUBARRAYS = (
+    "sub41s1_2-spectra", "sub82s2_4-spectra", "sub164s4_8-spectra",
+    "sub260s4_8-spectra",
+)
+NIRCAM_DHS_WEB_READOUTS = (
+    "optimize", "rapid", "bright1", "dhs3", "dhs4", "dhs5", "dhs6", "dhs7",
+)
+NIRISS_WEB_SUBARRAYS = (
+    "substrip256", "substrip96", "sub17stripe_soss", "sub60stripe_soss",
+    "sub204stripe_soss", "sub680stripe_soss",
+)
+
+
+def validate_online_instrument_configuration(conf):
+    """Reject incomplete or unsupported instrument selections before queuing work."""
+    instrument = conf.get("instrument", {})
+    detector = conf.get("detector", {})
+    name = str(instrument.get("instrument", "")).lower()
+    subarray = str(detector.get("subarray", "")).lower()
+    readout = str(detector.get("readout_pattern", "")).lower()
+
+    if name == "miri":
+        mode = str(instrument.get("mode", "")).lower()
+        if mode not in MIRI_LRS_ALLOWED_SUBARRAYS:
+            raise ValueError(f"Unsupported MIRI LRS mode: {mode}.")
+        validate_miri_lrs_subarray(conf)
+    elif name == "nirspec":
+        mode = f"{instrument.get('disperser', '')}{instrument.get('filter', '')}".lower()
+        if mode not in NIRSPEC_WEB_MODES:
+            raise ValueError(f"Unsupported NIRSpec BOTS mode: {mode}.")
+        allowed = NIRSPEC_STANDARD_SUBARRAYS
+        if mode == "prismclear":
+            allowed = tuple(
+                item for item in NIRSPEC_STANDARD_SUBARRAYS if item != "sub1024a"
+            ) + NIRSPEC_PRISM_MULTISTRIPE_SUBARRAYS
+        if subarray not in allowed:
+            raise ValueError(
+                f"NIRSpec mode {mode.upper()} does not support subarray "
+                f"{subarray.upper()}."
+            )
+        validate_nirspec_prism_subarray(conf)
+    elif name == "nircam" and subarray.endswith("-spectra"):
+        mode = str(instrument.get("mode", "")).lower()
+        filt = str(instrument.get("filter", "")).lower()
+        pair = str(instrument.get("pandexofilterpair", "")).lower()
+        if mode == "sw_tsgrism":
+            valid_filters = filt in NIRCAM_DHS_WEB_FILTERS and pair in NIRCAM_WEB_FILTERS
+        elif mode == "lw_tsgrism":
+            valid_filters = filt in NIRCAM_WEB_FILTERS and pair in NIRCAM_DHS_WEB_FILTERS
+        else:
+            valid_filters = False
+        if not valid_filters:
+            raise ValueError("Choose a valid paired NIRCam DHS filter configuration.")
+        if subarray not in NIRCAM_DHS_WEB_SUBARRAYS:
+            raise ValueError("Choose a valid NIRCam DHS subarray.")
+        if readout not in NIRCAM_DHS_WEB_READOUTS:
+            raise ValueError("Choose a valid NIRCam DHS readout pattern.")
+    elif name == "nircam":
+        if instrument.get("filter") not in NIRCAM_WEB_FILTERS:
+            raise ValueError("Choose F322W2 or F444W for NIRCam grism time series.")
+        if subarray not in NIRCAM_WEB_SUBARRAYS:
+            raise ValueError("Choose a valid NIRCam grism subarray.")
+        if readout not in NIRCAM_WEB_READOUTS:
+            raise ValueError("Choose a valid NIRCam grism readout pattern.")
+    elif name == "niriss" and subarray not in NIRISS_WEB_SUBARRAYS:
+        raise ValueError("Choose a valid NIRISS SOSS subarray.")
 
 #define location of fort grids
 try:
@@ -560,6 +643,10 @@ class CalculationNewHandler(BaseHandler):
             with open(os.path.join(os.path.dirname(__file__), "reference", "miri_input.json")) as data_file:
                 pandata = json.load(data_file)
                 mirimode = self.get_argument("mirimode")
+                if mirimode not in MIRI_LRS_ALLOWED_SUBARRAYS:
+                    raise tornado.web.HTTPError(
+                        400, reason=f"Unsupported MIRI LRS mode: {mirimode}."
+                    )
                 mirisubarray = self.get_argument(
                     "mirisubarray", MIRI_LRS_ALLOWED_SUBARRAYS[mirimode][0]
                 )
@@ -598,10 +685,6 @@ class CalculationNewHandler(BaseHandler):
                 pandata["configuration"]["instrument"]["disperser"] = nirspecmode[0:5]
                 pandata["configuration"]["instrument"]["filter"] = nirspecmode[5:11]
                 pandata["configuration"]["detector"]["subarray"] = nirspecsubarray
-                try:
-                    validate_nirspec_prism_subarray(pandata["configuration"])
-                except ValueError as exc:
-                    raise tornado.web.HTTPError(400, reason=str(exc))
 
         if instrument == "nircam":
             with open(os.path.join(os.path.dirname(__file__), "reference", "nircam_input.json")) as data_file:
@@ -617,6 +700,10 @@ class CalculationNewHandler(BaseHandler):
                 pandata = json.load(data_file)
                 # SW and LW are observed together, but PandExo displays one at a time.
                 sw_or_lw = self.get_argument("nircammode")
+                if sw_or_lw not in ("sw", "lw"):
+                    raise tornado.web.HTTPError(
+                        400, reason="Choose the NIRCam DHS short- or long-wave channel."
+                    )
                 filter_to_sim = f"nircam{sw_or_lw}"
                 if "sw" in filter_to_sim:
                     pair_filter = "nircamlw"
@@ -635,9 +722,23 @@ class CalculationNewHandler(BaseHandler):
                 nirissmode = self.get_argument("nirissmode")
                 pandata["configuration"]["detector"]["subarray"] = nirissmode
                 if nirissmode == "substrip256":
-                    pandata["strategy"]["order"] = int(self.get_argument("nirissorders"))
+                    try:
+                        order = int(self.get_argument("nirissorders"))
+                    except ValueError:
+                        raise tornado.web.HTTPError(
+                            400, reason="NIRISS SOSS order must be 1 or 2."
+                        )
+                    if order not in (1, 2):
+                        raise tornado.web.HTTPError(
+                            400, reason="NIRISS SOSS order must be 1 or 2."
+                        )
+                    pandata["strategy"]["order"] = order
 
         pandata['configuration']['instrument']['instrument'] = instrument.replace('dhs', '')
+        try:
+            validate_online_instrument_configuration(pandata["configuration"])
+        except ValueError as exc:
+            raise tornado.web.HTTPError(400, reason=str(exc))
 
         # write in optimal groups or set a number
         try:

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -23,6 +23,7 @@ from astroquery.simbad import Simbad
 import astropy.units as u
 
 from .pandexo import wrapper
+from .jwst import validate_nirspec_prism_subarray
 from .utils.plotters import create_component_jwst, create_component_hst
 from .logs import jwst_log, hst_log
 from .exomast import async_get_target_data
@@ -597,6 +598,10 @@ class CalculationNewHandler(BaseHandler):
                 pandata["configuration"]["instrument"]["disperser"] = nirspecmode[0:5]
                 pandata["configuration"]["instrument"]["filter"] = nirspecmode[5:11]
                 pandata["configuration"]["detector"]["subarray"] = nirspecsubarray
+                try:
+                    validate_nirspec_prism_subarray(pandata["configuration"])
+                except ValueError as exc:
+                    raise tornado.web.HTTPError(400, reason=str(exc))
 
         if instrument == "nircam":
             with open(os.path.join(os.path.dirname(__file__), "reference", "nircam_input.json")) as data_file:

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -678,6 +678,9 @@
             var mode = $("#nirspecmode").val();
             var options = nirspecStandardSubarrayOptions.slice();
             if (mode === "prismclear") {
+                options = options.filter(function (option) {
+                    return option.value !== "sub1024a";
+                });
                 options = options.concat(nirspecPrismMultistripeSubarrayOptions);
             }
             var current = $("#nirspecsubarray").val();

--- a/pandexo/engine/templates/new.html
+++ b/pandexo/engine/templates/new.html
@@ -764,23 +764,35 @@
         function showSelectedInstrumentMode() {
             $("#instrument-mode-section").removeClass("hidden");
             $("#MIRI, #NIRSpec, #NIRISS, #NIRCam, #NIRCamDHS").addClass("hidden");
+            $("#MIRI, #NIRSpec, #NIRISS, #NIRCam, #NIRCamDHS")
+                .find("select")
+                .prop("required", false);
             var selopt = $("#instrument").val();
+            var activeSection = "";
             switch (selopt) {
                 case "MIRI":
                     $("#MIRI").removeClass("hidden");
+                    activeSection = "#MIRI";
                     break;
                 case "NIRSpec":
                     $("#NIRSpec").removeClass("hidden");
+                    activeSection = "#NIRSpec";
                     break;
                 case "NIRISS":
                     $("#NIRISS").removeClass("hidden");
+                    activeSection = "#NIRISS";
                     break;
                 case "NIRCam":
                     $("#NIRCam").removeClass("hidden");
+                    activeSection = "#NIRCam";
                     break;
                 case "NIRCamDHS":
                     $("#NIRCamDHS").removeClass("hidden");
+                    activeSection = "#NIRCamDHS";
                     break;
+            }
+            if (activeSection) {
+                $(activeSection).find("select").prop("required", true);
             }
         }
 

--- a/tests/test_nirspec_valid_channels.py
+++ b/tests/test_nirspec_valid_channels.py
@@ -3,9 +3,11 @@ import pytest
 
 from pandexo.engine.jwst import (
     _pandeia_1d_values_at_wave,
+    compute_full_sim,
     dhs_f150w_wavelength_mask,
     nirspec_valid_channel_mask,
     nirspec_prism_multistripe_wavelength_mask,
+    validate_nirspec_prism_subarray,
 )
 
 
@@ -63,6 +65,35 @@ def test_nirspec_mask_rejects_unobserved_channels():
     )
 
     assert mask.tolist() == [True, False, False, False, True]
+
+
+def test_nirspec_prism_clear_rejects_sub1024a():
+    conf = {
+        "instrument": {
+            "instrument": "nirspec",
+            "disperser": "prism",
+            "filter": "clear",
+        },
+        "detector": {"subarray": "sub1024a"},
+    }
+
+    with pytest.raises(ValueError, match="PRISM/CLEAR.*SUB1024A"):
+        compute_full_sim(
+            {"pandeia_input": {"configuration": conf}, "pandexo_input": {}}
+        )
+
+
+def test_nirspec_prism_clear_accepts_supported_subarray():
+    conf = {
+        "instrument": {
+            "instrument": "nirspec",
+            "disperser": "prism",
+            "filter": "clear",
+        },
+        "detector": {"subarray": "sub1024b"},
+    }
+
+    assert validate_nirspec_prism_subarray(conf) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_online_instrument_validation.py
+++ b/tests/test_online_instrument_validation.py
@@ -1,0 +1,117 @@
+import itertools
+
+import pytest
+
+from pandexo.engine.run_online import (
+    MIRI_LRS_ALLOWED_SUBARRAYS,
+    NIRCAM_DHS_WEB_FILTERS,
+    NIRCAM_DHS_WEB_READOUTS,
+    NIRCAM_DHS_WEB_SUBARRAYS,
+    NIRCAM_WEB_FILTERS,
+    NIRCAM_WEB_READOUTS,
+    NIRCAM_WEB_SUBARRAYS,
+    NIRISS_WEB_SUBARRAYS,
+    NIRSPEC_PRISM_MULTISTRIPE_SUBARRAYS,
+    NIRSPEC_STANDARD_SUBARRAYS,
+    NIRSPEC_WEB_MODES,
+    validate_online_instrument_configuration,
+)
+
+
+def _configuration(instrument, detector, **instrument_values):
+    return {
+        "instrument": {"instrument": instrument, **instrument_values},
+        "detector": detector,
+    }
+
+
+def test_all_website_instrument_configurations_are_valid():
+    configurations = []
+    for mode, subarrays in MIRI_LRS_ALLOWED_SUBARRAYS.items():
+        configurations.extend(
+            _configuration("miri", {"subarray": subarray}, mode=mode)
+            for subarray in subarrays
+        )
+
+    for mode in NIRSPEC_WEB_MODES:
+        subarrays = NIRSPEC_STANDARD_SUBARRAYS
+        if mode == "prismclear":
+            subarrays = tuple(
+                subarray
+                for subarray in NIRSPEC_STANDARD_SUBARRAYS
+                if subarray != "sub1024a"
+            ) + NIRSPEC_PRISM_MULTISTRIPE_SUBARRAYS
+        configurations.extend(
+            _configuration(
+                "nirspec",
+                {"subarray": subarray},
+                disperser=mode[:5],
+                filter=mode[5:],
+            )
+            for subarray in subarrays
+        )
+
+    configurations.extend(
+        _configuration(
+            "nircam",
+            {"subarray": subarray, "readout_pattern": readout},
+            mode="lw_tsgrism",
+            filter=filt,
+        )
+        for filt, subarray, readout in itertools.product(
+            NIRCAM_WEB_FILTERS, NIRCAM_WEB_SUBARRAYS, NIRCAM_WEB_READOUTS
+        )
+    )
+
+    configurations.extend(
+        _configuration("niriss", {"subarray": subarray})
+        for subarray in NIRISS_WEB_SUBARRAYS
+    )
+
+    for display_mode in ("sw_tsgrism", "lw_tsgrism"):
+        for sw_filter, lw_filter, subarray, readout in itertools.product(
+            NIRCAM_DHS_WEB_FILTERS,
+            NIRCAM_WEB_FILTERS,
+            NIRCAM_DHS_WEB_SUBARRAYS,
+            NIRCAM_DHS_WEB_READOUTS,
+        ):
+            if display_mode == "sw_tsgrism":
+                filt, pair = sw_filter, lw_filter
+            else:
+                filt, pair = lw_filter, sw_filter
+            configurations.append(
+                _configuration(
+                    "nircam",
+                    {"subarray": subarray, "readout_pattern": readout},
+                    mode=display_mode,
+                    filter=filt,
+                    pandexofilterpair=pair,
+                )
+            )
+
+    for conf in configurations:
+        assert validate_online_instrument_configuration(conf) is None
+
+
+@pytest.mark.parametrize(
+    "conf",
+    [
+        _configuration("miri", {"subarray": "full"}, mode="lrsslitless"),
+        _configuration(
+            "nirspec",
+            {"subarray": "s64m8_prm"},
+            disperser="g395h",
+            filter="f290lp",
+        ),
+        _configuration(
+            "nircam",
+            {"subarray": "", "readout_pattern": "rapid"},
+            mode="lw_tsgrism",
+            filter="f444w",
+        ),
+        _configuration("niriss", {"subarray": ""}),
+    ],
+)
+def test_online_instrument_validation_rejects_invalid_choices(conf):
+    with pytest.raises(ValueError):
+        validate_online_instrument_configuration(conf)

--- a/tests/test_run_online_templates.py
+++ b/tests/test_run_online_templates.py
@@ -101,6 +101,7 @@ def test_new_calculation_template_gates_nirspec_multistripe_subarrays():
     assert "nirspecStandardSubarrayOptions" in template
     assert "nirspecPrismMultistripeSubarrayOptions" in template
     assert 'if (mode === "prismclear")' in template
+    assert 'option.value !== "sub1024a"' in template
     assert "options.concat(nirspecPrismMultistripeSubarrayOptions)" in template
     assert '$("#nirspecmode").change(updateNirspecSubarrayOptions)' in template
     assert "updateNirspecSubarrayOptions();" in template


### PR DESCRIPTION
## Summary

- Reject NIRSpec PRISM/CLEAR with the unsupported `SUB1024A` subarray before Pandeia is invoked.
- Hide `SUB1024A` from PRISM/CLEAR subarray choices.
- Require selections only for the currently active website instrument controls.
- Validate all website-submitted MIRI, NIRSpec, NIRISS, NIRCam grism, and NIRCam DHS configurations before queuing a calculation.
- Return clear HTTP 400 errors for incomplete or tampered instrument selections.
- Add regression coverage for the PRISM/CLEAR restriction and every non-empty website-supported instrument configuration.

## Validation

```text
42 passed
```