### PR TITLE
Polish and complete the PandExo 2026.7 documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 1"
 
 jobs:
   docs:
@@ -40,6 +42,30 @@ jobs:
 
       - name: Build documentation
         run: sphinx-build -E -W --keep-going -b html docs docs/_build/html
+
+  linkcheck:
+    name: Documentation links
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and documentation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[docs]"
+
+      - name: Check external documentation links
+        run: sphinx-build -E -W --keep-going -b linkcheck docs docs/_build/linkcheck
 
   package:
     name: Package validation

--- a/docs/engine.rst
+++ b/docs/engine.rst
@@ -1,21 +1,24 @@
 API Reference
 =============
 
+Primary Public API
+------------------
 
 pandexo.engine.justdoit
 -----------------------
 
 .. automodule:: pandexo.engine.justdoit
     :members:
-    :undoc-members:
     :show-inheritance:
+
+Plotting Helpers
+----------------
 
 pandexo.engine.justplotit
 -------------------------
 
 .. automodule:: pandexo.engine.justplotit
     :members:
-    :undoc-members:
     :show-inheritance:
 
 pandexo.engine.bintools
@@ -23,8 +26,24 @@ pandexo.engine.bintools
 
 .. automodule:: pandexo.engine.bintools
     :members:
-    :undoc-members:
     :show-inheritance:
+
+Configuration Helpers
+---------------------
+
+pandexo.engine.load_modes
+-------------------------
+
+.. automodule:: pandexo.engine.load_modes
+    :members:
+    :show-inheritance:
+
+Advanced and Internal Modules
+-----------------------------
+
+These modules support PandExo's calculation engine and web application. Their
+interfaces may change between releases; use ``pandexo.engine.justdoit`` for
+new scripts when possible.
 
 pandexo.engine.run_online
 -------------------------
@@ -65,14 +84,6 @@ pandexo.engine.jwst
 .. automodule:: pandexo.engine.jwst
     :members:
     :exclude-members: ExtractSpec
-    :undoc-members:
-    :show-inheritance:
-
-pandexo.engine.load_modes
--------------------------
-
-.. automodule:: pandexo.engine.load_modes
-    :members:
     :undoc-members:
     :show-inheritance:
 

--- a/docs/includeme.rst
+++ b/docs/includeme.rst
@@ -4,7 +4,9 @@
 .. only:: html
 
    .. image:: https://zenodo.org/badge/67237418.svg
+      :alt: PandExo Zenodo DOI.
       :target: https://zenodo.org/badge/latestdoi/67237418
 
    .. image:: https://github.com/natashabatalha/PandExo/actions/workflows/tests.yml/badge.svg?branch=master
+      :alt: PandExo test workflow status.
       :target: https://github.com/natashabatalha/PandExo/actions/workflows/tests.yml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,19 +4,28 @@
    contain the root `toctree` directive.
 
 .. image:: logo.png
+   :alt: PandExo logo.
    :width: 450px
    :align: center
 
-The Documentation
-=================
+PandExo Documentation
+=====================
 
 Tools to help the community with planning exoplanet observations.
 
 .. note::
-    The online PandExo module has moved to
-    `STScI's ExoCTK <https://exoctk.stsci.edu/pandexo/>`_. 
+    Use the `PandExo web interface on STScI's ExoCTK
+    <https://exoctk.stsci.edu/pandexo/>`_ for browser-based calculations.
 
-PandExo is both an online tool and a Python package for generating instrument simulations of JWST's NIRSpec, NIRCam, NIRISS, and MIRI, and HST's WFC3. It uses throughput calculations from STScI's Exposure Time Calculator, Pandeia: Pandeia + Exoplanets = PandExo. This documentation contains information on how to download, install, and analyze PandExo output.
+PandExo is both an online tool and a Python package for generating instrument
+simulations of JWST's NIRSpec, NIRCam, NIRISS, and MIRI, and HST's WFC3. It
+uses throughput calculations from STScI's Exposure Time Calculator, Pandeia:
+Pandeia + Exoplanets = PandExo.
+
+Start with :doc:`installation` to configure the local package and required
+reference data. Then follow the :doc:`tutorialjwst` or :doc:`tutorialhst`, use
+:doc:`jwstinput` to select a supported instrument configuration, and consult
+:doc:`jwstdict` when analyzing a completed calculation.
 
 Citation: `PandExo: A Community Tool for Transiting Exoplanet Science with JWST and HST <https://ui.adsabs.harvard.edu/abs/2017PASP..129f4501B>`_
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -134,20 +134,31 @@ the same shell startup file and source that file again:
 Installation with Pip or Git
 ============================
 
-Install with pip: 
+Install PandExo in a dedicated virtual environment so its dependencies do not
+affect other projects. For example, with Python's built-in ``venv``:
+
+.. code-block:: bash
+
+    python -m venv pandexo-env
+    source pandexo-env/bin/activate
+
+On Windows, use the conda-based instructions in :doc:`installation_windows`.
+
+Install with pip:
 
 .. code-block:: bash
 
     python -m pip install pandexo.engine
 
 
-OR Download PandExo's repository via Github. The Github also has helpful notebooks for getting started!
+Alternatively, clone PandExo from GitHub. The repository includes notebooks for
+getting started:
 
 .. code-block:: bash
 
     git clone https://github.com/natashabatalha/PandExo.git
     cd PandExo
-    python -m pip install .
+    python -m pip install -e .
 
 
 
@@ -168,7 +179,11 @@ test, install the test dependency and run the test from the repository root:
 .. code-block:: bash
 
     python -m pip install -e ".[test]"
-    python -m pytest tests/test_run.py -q
+    python -m pytest tests/test_import.py -q
+
+The full ``tests/test_run.py`` suite runs Pandeia calculations and requires the
+reference data configured above. Run it only when validating a source checkout
+with a complete local data installation.
 
 
 The Importance of Upgrading PandExo

--- a/docs/installation_windows.rst
+++ b/docs/installation_windows.rst
@@ -1,23 +1,22 @@
-Windows Installing Guide for PandExo
-====================================
+Windows Installation Guide for PandExo
+======================================
 
 Created by J. N. van Haastere (Physics and Astronomy bachelor's student),
 University of Amsterdam and VU University Amsterdam.
 
-Step 1 
-``````
+Step 1: Install Conda
+`````````````````````
 
 Create a dedicated conda environment; uninstalling other Python versions is
 not necessary.
 
-Step 2
-``````
-
 `Download most recent Anaconda version <https://www.anaconda.com/download/>`_.
-PandExo supports Python 3.10 and newer.
-    
-Step 3
-``````
+Miniconda is sufficient. PandExo requires Python 3.10 or later; continuous
+integration currently tests Python 3.10 through 3.12, while Python 3.13 is
+also exercised as a non-blocking compatibility check.
+
+Step 2: Create an Environment
+`````````````````````````````
 
 Install Anaconda or Miniconda, then create and activate an environment:
 
@@ -27,75 +26,109 @@ Install Anaconda or Miniconda, then create and activate an environment:
     conda activate pandexo
 
 .. note::
-    If successfully installed, ``python --version`` reports Python 3.10 or newer.
+    Verify that ``python --version`` reports Python 3.10 or later.
 
-Step 4
-``````
+Step 3: Optional Build Tools
+````````````````````````````
 Visual Studio build tools are not normally required. If pip must compile a
 dependency, install the current `Microsoft C++ Build Tools
 <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_.
-    
-Step 5
-``````
 
-`Follow PandExo Installation guide in getting files <https://natashabatalha.github.io/PandExo/installation.html>`_
-
-- get Pandeia data v2026p7
-- get Pandeia PSFs v2026p7
-- get stellar reference data for synphot/stsynphot (includes phoenix models and
-  throughputs)
-
-
-Step 6: Setting Reference Data
+Step 4: Download Reference Data
 ```````````````````````````````
-Using an archiver (for example, 7-Zip), extract Pandeia, the Pandeia PSFs, and
-the stellar reference data into separate folders. The 2026.7 JWST files are
-available here:
+Using an archiver such as 7-Zip, extract the following archives. Keep Pandeia
+reference data, PSFs, and synphot data in separate locations. The 2026.7 JWST
+files are available here:
 
 - `Pandeia data v2026p7 JWST <https://stsci.app.box.com/v/pandeia-data-v2026p7-jwst>`_
 - `Pandeia PSFs v2026p7 JWST <https://stsci.app.box.com/v/pandeia-psfs-v2026p7-jwst>`_
+- `PHOENIX stellar reference atlas <https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_pheonix-models_multi_v3_synphot5.tar>`_
+- `Normalization bandpasses <https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v11_sed.tar>`_
 
-.. code-block:: bash
+The stellar and normalization archives both extract a ``grp/redcat/trds``
+tree. ``PYSYN_CDBS`` must name the PHOENIX archive's ``trds`` directory, not
+its parent ``grp`` directory. Copy the normalization archive's ``comp`` and
+``mtab`` *contents* into the matching directories under that same
+``PYSYN_CDBS`` directory. Do not nest another ``grp/redcat/trds`` tree there.
 
-    C:/Users/USERNAME/pandeia_data-2026.7-jwst
-    C:/Users/USERNAME/pandeia_psfs-2026.7-jwst
-    C:/Users/USERNAME/stellar_reference_data/grp/redcat/trds
+Step 5: Set Reference-Data Variables
+`````````````````````````````````````
+The following PowerShell commands set each variable for the current terminal
+and persist it for future terminals. Replace the example paths before running
+them. Start a new PowerShell or Anaconda Prompt after using this step so the
+persistent values are loaded automatically.
 
-The variable names are ``pandeia_refdata``, ``PSF_DIR``, and ``PYSYN_CDBS``.
+.. code-block:: powershell
 
-Set these in Windows environment variables / registry using SETX. Open CMD or Anaconda Prompt and run:   
+    $env:pandeia_refdata = "$HOME\pandexo-data\pandeia_data-2026.7-jwst"
+    $env:PSF_DIR = "$HOME\pandexo-data\pandeia_psfs-2026.7-jwst"
+    $env:PYSYN_CDBS = "$HOME\pandexo-data\phoenix\grp\redcat\trds"
 
-.. code-block:: bash
+    [Environment]::SetEnvironmentVariable('pandeia_refdata', $env:pandeia_refdata, 'User')
+    [Environment]::SetEnvironmentVariable('PSF_DIR', $env:PSF_DIR, 'User')
+    [Environment]::SetEnvironmentVariable('PYSYN_CDBS', $env:PYSYN_CDBS, 'User')
 
-    SETX pandeia_refdata "C:/Users/USERNAME/pandeia_data-2026.7-jwst"
-    SETX PSF_DIR "C:/Users/USERNAME/pandeia_psfs-2026.7-jwst"
-    SETX PYSYN_CDBS "C:/Users/USERNAME/stellar_reference_data/grp/redcat/trds"
+Copy the normalization ``comp`` and ``mtab`` contents into ``PYSYN_CDBS``. In
+this example, ``$normalizationTrds`` is the ``trds`` directory extracted from
+the normalization archive:
 
-The ``SETX`` command persists these variables for future terminals, but it
-usually does not update the current open terminal. Close and reopen CMD,
-PowerShell, or Anaconda Prompt before checking the values.
+.. code-block:: powershell
 
-You can check this step by opening a new CMD and run > SET
+    $normalizationTrds = "$HOME\pandexo-data\normalization\grp\redcat\trds"
+    Copy-Item -Recurse -Force "$normalizationTrds\comp\*" "$env:PYSYN_CDBS\comp\"
+    Copy-Item -Recurse -Force "$normalizationTrds\mtab\*" "$env:PYSYN_CDBS\mtab\"
 
-Step 7: Installing needed Packages
-``````````````````````````````````
+Verify the current terminal's variables and required files:
 
-Install PandExo Engine
+.. code-block:: powershell
 
-.. code-block:: bash
+    Get-ChildItem $env:PYSYN_CDBS
+    Test-Path "$env:PYSYN_CDBS\comp\nonhst\bessell_j_003_syn.fits"
+    Test-Path "$env:PYSYN_CDBS\grid\phoenix\catalog.fits"
+
+For Command Prompt instead of PowerShell, set the current terminal and its
+persistent replacement separately:
+
+.. code-block:: bat
+
+    set "pandeia_refdata=C:\Users\USERNAME\pandexo-data\pandeia_data-2026.7-jwst"
+    setx pandeia_refdata "%pandeia_refdata%"
+
+Repeat the pair of commands for ``PSF_DIR`` and ``PYSYN_CDBS``. ``setx`` only
+affects future terminals, so retain ``set`` for the current Command Prompt.
+
+Step 6: Install PandExo
+```````````````````````
+
+.. code-block:: powershell
 
     python -m pip install pandexo.engine
 
-See the main :doc:`installation` guide if you run into problems.
+Confirm that PandExo can see the reference data:
 
-Step 8: Run Test
-````````````````
-Navigate to the PandExo source checkout and run the smoke test.
+.. code-block:: powershell
 
-.. code-block:: bash 
+    python -c "import pandeia.engine; pandeia.engine.pandeia_version()"
 
-    cd '...'
-    python -m pytest tests/test_run.py -q
+Step 7: Validate the Installation
+``````````````````````````````````
+
+For a normal pip installation, run this lightweight installed-package smoke
+test. It does not start the web application or run a simulation:
+
+.. code-block:: powershell
+
+    python -c "import pandexo.engine.justdoit as jdi; mode = jdi.load_mode_dict('NIRSpec Prism'); assert mode['configuration']['instrument']['disperser'] == 'prism'; print('PandExo configuration smoke test passed.')"
+
+To run repository tests, first clone the source checkout and install its test
+dependencies. This command applies only inside that checkout:
+
+.. code-block:: powershell
+
+    git clone https://github.com/natashabatalha/PandExo.git
+    cd PandExo
+    python -m pip install -e ".[test]"
+    python -m pytest tests/test_import.py -q
 
 Congrats on being persevering/stubborn enough to get PandExo to work on Windows!
 There are some example Jupyter notebooks to try in ``PandExo/notebooks``.

--- a/docs/installation_windows.rst
+++ b/docs/installation_windows.rst
@@ -75,16 +75,32 @@ the normalization archive:
 .. code-block:: powershell
 
     $normalizationTrds = "$HOME\pandexo-data\normalization\grp\redcat\trds"
-    Copy-Item -Recurse -Force "$normalizationTrds\comp\*" "$env:PYSYN_CDBS\comp\"
-    Copy-Item -Recurse -Force "$normalizationTrds\mtab\*" "$env:PYSYN_CDBS\mtab\"
+    New-Item -ItemType Directory -Force "$env:PYSYN_CDBS\comp" | Out-Null
+    New-Item -ItemType Directory -Force "$env:PYSYN_CDBS\mtab" | Out-Null
+
+    Copy-Item -Recurse -Force `
+        "$normalizationTrds\comp\*" `
+        "$env:PYSYN_CDBS\comp\"
+
+    Copy-Item -Recurse -Force `
+        "$normalizationTrds\mtab\*" `
+        "$env:PYSYN_CDBS\mtab\"
 
 Verify the current terminal's variables and required files:
 
 .. code-block:: powershell
 
-    Get-ChildItem $env:PYSYN_CDBS
+    $env:pandeia_refdata
+    $env:PSF_DIR
+    $env:PYSYN_CDBS
+    Test-Path $env:pandeia_refdata
+    Test-Path $env:PSF_DIR
+    Test-Path "$env:PYSYN_CDBS\comp"
+    Test-Path "$env:PYSYN_CDBS\grid"
+    Test-Path "$env:PYSYN_CDBS\mtab"
     Test-Path "$env:PYSYN_CDBS\comp\nonhst\bessell_j_003_syn.fits"
     Test-Path "$env:PYSYN_CDBS\grid\phoenix\catalog.fits"
+    (Get-ChildItem "$env:PYSYN_CDBS\mtab" -File -Recurse | Measure-Object).Count -gt 0
 
 For Command Prompt instead of PowerShell, set the current terminal and its
 persistent replacement separately:
@@ -123,6 +139,9 @@ test. It does not start the web application or run a simulation:
 To run repository tests, first clone the source checkout and install its test
 dependencies. This command applies only inside that checkout:
 
+Install `Git for Windows <https://git-scm.com/download/win>`_ to use
+``git clone``. Git is not required for a normal pip installation.
+
 .. code-block:: powershell
 
     git clone https://github.com/natashabatalha/PandExo.git
@@ -130,5 +149,5 @@ dependencies. This command applies only inside that checkout:
     python -m pip install -e ".[test]"
     python -m pytest tests/test_import.py -q
 
-Congrats on being persevering/stubborn enough to get PandExo to work on Windows!
-There are some example Jupyter notebooks to try in ``PandExo/notebooks``.
+PandExo is now ready to use. See the example Jupyter notebooks in
+``PandExo/notebooks`` to get started.

--- a/docs/jwstdict.rst
+++ b/docs/jwstdict.rst
@@ -151,6 +151,13 @@ corresponding dictionaries for programmatic analysis.
 Saved ``.p`` results are Python pickle files. Only load files from trusted
 sources, because unpickling an untrusted file can execute arbitrary code.
 
+.. code:: python
+
+    import pickle
+
+    with open("singlerun.p", "rb") as handle:
+        result = pickle.load(handle)  # Load only files from trusted sources.
+
 .. _Python dictionary: https://docs.python.org/3/tutorial/datastructures.html#dictionaries
 .. _example notebooks: https://github.com/natashabatalha/PandExo/tree/master/notebooks
 .. _STScI's Pandeia Documentation: https://jwst-docs.stsci.edu/jwst-exposure-time-calculator-overview/jwst-etc-pandeia-engine-tutorial

--- a/docs/jwstdict.rst
+++ b/docs/jwstdict.rst
@@ -1,20 +1,28 @@
-Py Dict Structure of JWST Output
-================================
+JWST Output Dictionary
+======================
 
-The PandExo output is organized into `Python Dictionaries`_. See
-`example notebooks`_ for an explanation of how to manipulate these and
-plot the most common outputs. Below is a breakdown of everything
-contained in the PandExo output dictionary. 
+PandExo returns a nested `Python dictionary`_. See the `example notebooks`_
+for common analysis and plotting patterns. The exact fields vary by instrument
+mode and selected options, so inspect the result you receive rather than
+assuming every calculation has every key:
+
+.. code:: python
+
+    print(result.keys())
+    print(result['FinalSpectrum'].keys())
+
+The arrays in ``FinalSpectrum`` and ``RawData`` are NumPy arrays. Wavelengths
+are in microns unless a field name or the associated metadata states otherwise.
 
 FinalSpectrum
 ~~~~~~~~~~~~~
 
--  **spectrum\_w\_rand**: Planet spectrum with random noise added in
-   units of *(Rp/Rs)2* or *(Fp/Fs)*
--  **spectrum**: Planet spectrum with no random noise
+-  **spectrum\_w\_rand**: Planet spectrum with random noise added, in
+   ``(Rp/Rs)^2`` or ``Fp/Fs``.
+-  **spectrum**: Planet spectrum without random noise.
 -  **error\_w\_floor**: Error with user defined noise floor. If no floor
    was specified, there is no floor.
--  **wave**: wavelength (microns)
+-  **wave**: Wavelength in microns.
 
 .. code:: python 
 
@@ -23,9 +31,9 @@ FinalSpectrum
 OriginalInput
 ~~~~~~~~~~~~~
 
--  **model\_wave**: original wavelength input by user
--  **model\_spec**: original spectrum input by user
--  **star\_spec**: out-of-transit stellar spectrum used by PandExo
+-  **model\_wave**: Original wavelength array supplied by the user.
+-  **model\_spec**: Original planet spectrum supplied by the user.
+-  **star\_spec**: Out-of-transit stellar spectrum used by PandExo.
 
 .. code:: python 
 
@@ -53,7 +61,7 @@ warning
 
 Mode-specific calculations can add warnings for NIRCam readout optimization
 and data excess, NIRSpec long exposures, MIRI slit-mode TSO use, or target
-acquisition.
+acquisition. Warning values and their availability vary by mode.
 
 .. code:: python 
 
@@ -62,9 +70,9 @@ acquisition.
 PandeiaOutTrans
 ~~~~~~~~~~~~~~~
 
-This is the raw output of Pandeia's simulation of the out of transit
-observation. For a complete breakdown of these outputs go to `STScI's
-Pandeia Documentation`_. 
+This is the raw output of Pandeia's out-of-transit simulation. For a complete
+breakdown, see `STScI's Pandeia documentation`_. Its nested fields are
+Pandeia-version and mode dependent.
 
 - **sub\_reports** 
 - **information** 
@@ -82,10 +90,10 @@ Pandeia Documentation`_.
 RawData
 ~~~~~~~
 
--  **var\_in**: The variance of only the in transit data
--  **wave**: wavelength vector
--  **electrons\_in**, **electrons\_out**: Total in- and out-of-transit electrons
--  **e\_rate\_in**, **e\_rate\_out**: In- and out-of-transit electron rates
+-  **var\_in**: Variance of the in-transit data.
+-  **wave**: Wavelength vector in microns.
+-  **electrons\_in**, **electrons\_out**: Total in- and out-of-transit electrons.
+-  **e\_rate\_in**, **e\_rate\_out**: In- and out-of-transit electron rates.
 -  **electron\_per\_int** and **snr\_int**: Per-integration diagnostics
 -  **error\_no\_floor**: Error without any noise floor
 -  **var\_out**: The variance of only the out of transit data
@@ -124,7 +132,7 @@ input
 -  **Filter**
 -  **Instrument**
 -  **Mode**
--  **Saturation Level (electons)**
+-  **Saturation Level (electrons)**
 -  **Aperture**
 -  **Subarray**
 -  **Primary/Secondary**
@@ -140,6 +148,9 @@ HTML display fields
 ``warnings_div`` contain HTML tables rendered on the website. Use the
 corresponding dictionaries for programmatic analysis.
 
-.. _Python Dictionaries: https://docs.python.org/3/tutorial/datastructures.html#dictionaries
+Saved ``.p`` results are Python pickle files. Only load files from trusted
+sources, because unpickling an untrusted file can execute arbitrary code.
+
+.. _Python dictionary: https://docs.python.org/3/tutorial/datastructures.html#dictionaries
 .. _example notebooks: https://github.com/natashabatalha/PandExo/tree/master/notebooks
 .. _STScI's Pandeia Documentation: https://jwst-docs.stsci.edu/jwst-exposure-time-calculator-overview/jwst-etc-pandeia-engine-tutorial

--- a/docs/jwstinput.rst
+++ b/docs/jwstinput.rst
@@ -1,11 +1,11 @@
-Possible Instrument Input Params
-================================
+Instrument Configuration Parameters
+====================================
 
 Instrument dictionaries use Pandeia's lowercase configuration values. Load a
 template with ``jdi.load_mode_dict('NIRSpec G395H')``, then edit its
-``configuration`` keys.
-The values below are the combinations exposed by PandExo's web interface;
-confirm final timing and detector settings in the current APT.
+``configuration`` keys. The values below describe the 2026.7 PandExo release
+and the combinations exposed by its web interface; confirm final timing and
+detector settings in the current APT.
 
 NIRSpec 
 -------
@@ -57,7 +57,8 @@ Groups and readouts
 
 Set ``inst_dict['configuration']['detector']['ngroup'] = 'optimize'`` to let
 PandExo select a group count, or enter an integer valid for the selected
-Pandeia detector configuration. NIRCam and DHS templates also accept
+Pandeia detector configuration. ``optimize`` is a PandExo convenience value,
+not a native Pandeia detector value. NIRCam and DHS templates also accept
 ``readout_pattern = 'optimize'`` to account for saturation and estimated data
 excess when choosing a readout.
 

--- a/docs/tutorialhst.rst
+++ b/docs/tutorialhst.rst
@@ -1,9 +1,10 @@
-HST Tutorial 
-===============
+HST Tutorial
+============
 
-This file demonstrates how to use PandExo to predict the:
-1. Transmission/emission spectrum S/N ratio
-2. Observation start window for any system observed with WFC3/IR.
+This tutorial demonstrates how to use PandExo to predict:
+
+1. The transmission or emission spectrum signal-to-noise ratio.
+2. The observation start window for a system observed with WFC3/IR.
 
 .. code:: python
     
@@ -26,21 +27,21 @@ Edit stellar and planet inputs
 
 .. code:: python
 
-    #WASP-43
+    # WASP-43
     exo_dict['star']['jmag']     = 9.995                # J magnitude of the system
     exo_dict['star']['hmag']     = 9.397                # H magnitude of the system
-    #WASP-43b
+    # WASP-43b
     exo_dict['planet']['type']    = 'user'               # user specified inputs
     exo_dict['planet']['exopath'] = str(
         files('pandexo.engine.reference').joinpath('WASP43b-Eclipse_Spectrum.txt')
-    ) # packaged model spectrum
+    )  # Packaged model spectrum.
     exo_dict['planet']['w_unit']  = 'um'                 # wavelength unit
     exo_dict['planet']['f_unit']  = 'fp/f*'              # flux ratio unit (can also put "rp^2/r*^2")
     exo_dict['planet']['depth']   = 4.0e-3               # flux ratio
     exo_dict['planet']['i']       = 82.6                 # Orbital inclination in degrees
     exo_dict['planet']['ars']     = 5.13                 # Semi-major axis / stellar radius
     exo_dict['planet']['period']  = 0.8135               # Orbital period in days   
-    exo_dict['planet']['transit_duration']= 4170.0/60/60/24#(optional if given above info) transit duration in days
+    exo_dict['planet']['transit_duration'] = 4170.0/60/60/24  # Optional if given above information.
     exo_dict['planet']['w']       = 90                   #(optional) longitude of periastron. Default is 90
     exo_dict['planet']['ecc']     = 0                    #(optional) eccentricity. Default is 0 
 
@@ -72,13 +73,17 @@ Edit HST/WFC3 detector and observation inputs
 Run PandExo Command Line
 ------------------------
 
-``jdi.run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,                             output_path=os.getcwd(), output_file = '')``
+``jdi.run_pandexo(exo, inst, param_space=0, param_range=0, save_file=True,
+output_path=None, output_file='', num_cores=None, verbose=True)``
 
-See the API reference for a more thorough explanation of the inputs.
+``output_path=None`` resolves to the working directory when the calculation is
+run. Set ``save_file=False`` while exploring examples to avoid overwriting a
+pickle file; use an explicit ``output_path`` and ``output_file`` when you want
+to retain a result.
 
 .. code:: python
 
-    foo = jdi.run_pandexo(exo_dict, inst_dict, output_file='wasp43b.p')
+    foo = jdi.run_pandexo(exo_dict, inst_dict, save_file=False)
     Running Single Case w/ User Instrument Dict
     ****WARNING: Observing plan may incur mid-orbit buffer dumps.  Check with APT.
 
@@ -86,43 +91,54 @@ See the API reference for a more thorough explanation of the inputs.
 
     inst_dict['configuration']['detector']['nsamp'] = None
     inst_dict['configuration']['detector']['samp_seq'] = None
-    bar = jdi.run_pandexo(exo_dict, inst_dict, output_file='wasp43b.p')
+    bar = jdi.run_pandexo(exo_dict, inst_dict, save_file=False)
     Running Single Case w/ User Instrument Dict
 
 .. code:: python
 
     inst_dict['strategy']['scanDirection'] = 'Round Trip'
-    hst = jdi.run_pandexo(exo_dict, inst_dict, output_file='wasp43b.p')
+    hst = jdi.run_pandexo(exo_dict, inst_dict, save_file=False)
     Running Single Case w/ User Instrument Dict
 
 Plot Results
 ------------
 
-Plot simulated spectrum using specified file
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Plot Simulated Spectrum
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    import pandexo.engine.justplotit as jpi 
-    #using foo from above
-    #other keys include model=True/False
+    import pandexo.engine.justplotit as jpi
+    # Use foo from above. Other keys include model=True/False.
     datawave, dataspec, dataerror, modelwave, modelspec = jpi.hst_spec(foo)
 
-.. image:: hst_spec.png
+.. figure:: hst_spec.png
+   :alt: Simulated WFC3 spectrum for the HST tutorial example.
 
-Compute earliest and latest start times for given start window size
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The errors in the time series are the error per wavelength channel.
+   Simulated WFC3 spectrum for the configured WASP-43b observation.
+
+Compute the Earliest and Latest Start Times
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The errors in the time series are the error per wavelength channel. Values are
+illustrative and can vary with the PandExo, Pandeia, and reference-data
+versions used for a calculation.
 
 .. code:: python
 
-    #using foo from above
+    # Use foo from above.
     obsphase1, obstr1, obsphase2, obstr2,rms = jpi.hst_time(foo)
 
-.. image:: hst_time1.png
-    :width: 49 %  
-.. image:: hst_time2.png
-    :width: 49 %
+.. figure:: hst_time1.png
+   :alt: First WFC3 start-window diagnostic for the HST tutorial example.
+   :width: 49%
+
+   First start-window diagnostic.
+
+.. figure:: hst_time2.png
+   :alt: Second WFC3 start-window diagnostic for the HST tutorial example.
+   :width: 49%
+
+   Second start-window diagnostic.
 
 Print important info for observation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/tutorialjwst.rst
+++ b/docs/tutorialjwst.rst
@@ -23,7 +23,7 @@ Here you will learn how to:
 
     import warnings
     warnings.filterwarnings('ignore')
-    import pandexo.engine.justdoit as jdi # THIS IS THE HOLY GRAIL OF PANDEXO
+    import pandexo.engine.justdoit as jdi
     import pandexo.engine.justplotit as jpi
     import numpy as np
     import os
@@ -65,7 +65,7 @@ reproducible.
     exo_dict['observation']['sat_unit'] = '%'
     exo_dict['observation']['noccultations'] = 1 #number of transits
     exo_dict['observation']['R'] = None          #fixed binning. I usually suggest ZERO binning.. you can always bin later
-                                                 #without having to redo the calcualtion
+                                                 #without having to redo the calculation
     exo_dict['observation']['baseline_unit'] = 'total'  #Defines how you specify out of transit observing time
                                                         #'frac' : fraction of time in transit versus out = in/out
                                                         #'total' : total observing time (seconds)
@@ -101,28 +101,19 @@ Option 2) Input as dictionary or filename
 
 .. code:: ipython3
 
-    #Let's create a little fake stellar input
-
-    import scipy.constants as sc
+    # Create an arbitrary user-supplied stellar spectral shape. PandExo
+    # normalizes it to the magnitude and reference wavelength below.
     wl = np.linspace(0.5, 15, 3000)
-    nu = sc.c/(wl*1e-6)  # frequency in sec^-1
-    teff = 5500.0
-    planck_5500K = nu**3 / (np.exp(sc.h*nu/sc.k/teff) - 1)
 
-    #can either be dictionary input
-    starflux = {'f':planck_5500K, 'w':wl}
-    #or can be as a stellar file
-    #starflux = 'planck_5500K.dat'
-    #with open(starflux, 'w') as sf:
-    #    for w,f in zip(wl, planck_5500K):
-    #        sf.write(f'{w:.15f}   {f:.15e}\n')
+    # A user spectrum can be supplied as a dictionary or a two-column file.
+    starflux = {'f': (wl / 1.25)**-2, 'w': wl}
 
     exo_dict['star']['type'] = 'user'
     exo_dict['star']['mag'] = 10.0              #magnitude of the system
     exo_dict['star']['ref_wave'] = 1.25
     exo_dict['star']['starpath'] = starflux
     exo_dict['star']['w_unit'] = 'um'
-    exo_dict['star']['f_unit'] = 'erg/cm2/s/Hz'
+    exo_dict['star']['f_unit'] = 'jy'
 
 Edit exoplanet inputs using one of three options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,14 +127,13 @@ Edit exoplanet inputs using one of three options
 
 .. code:: ipython3
 
-    exo_dict['planet']['type'] ='user'                       #tells pandexo you are uploading your own spectrum
-    exo_dict['planet']['exopath'] = 'wasp12b.txt'
+    exo_dict['planet']['type'] = 'user'                      # Upload a user spectrum.
+    wavelength = np.linspace(0.6, 5.3, 500)
+    spectrum = np.full_like(wavelength, 0.015)
+    exo_dict['planet']['exopath'] = {'f': spectrum, 'w': wavelength}
 
-    #or as a dictionary
-    #exo_dict['planet']['exopath'] = {'f':spectrum, 'w':wavelength}
-
-    exo_dict['planet']['w_unit'] = 'cm'                      #other options include "um","nm" ,"Angs", "sec" (for phase curves)
-    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'               #other options are 'fp/f*'
+    exo_dict['planet']['w_unit'] = 'um'                      # Other options include nm, Angs, and sec (phase curves).
+    exo_dict['planet']['f_unit'] = 'rp^2/r*^2'               # The other option is fp/f*.
     exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration
     exo_dict['planet']['td_unit'] = 's'                      #Any unit of time in accordance with astropy.units can be added
 
@@ -166,11 +156,10 @@ Edit exoplanet inputs using one of three options
     #exo_dict['planet']['f_unit'] = 'fp/f*'
     #exo_dict['planet']['temp'] = 1000
 
-3) Select from grid
-"""""""""""""""""""
+3) Select from a grid
+"""""""""""""""""""""
 
-NOTE: Currently only the fortney grid for hot Jupiters from Fortney+2010
-is supported. Holler though, if you want another grid supported
+Currently, PandExo supports the Fortney et al. (2010) hot-Jupiter grid.
 
 .. code:: ipython3
 
@@ -209,10 +198,9 @@ NIRSpec G140M - NIRSpec G140H - MIRI LRS - NIRISS SOSS
 
     inst_dict = jdi.load_mode_dict('NIRSpec G140H')
 
-    #loading in instrument dictionaries allow you to personalize some of
-    #the fields that are predefined in the templates. The templates have
-    #the subbarays with the lowest frame times and the readmodes with 1 frame per group.
-    #if that is not what you want. change these fields
+    # Loading an instrument dictionary lets you personalize template fields.
+    # Templates use subarrays with the lowest frame times and readout modes
+    # with one frame per group; change these fields when needed.
 
     #Try printing this out to get a feel for how it is structured:
 
@@ -287,10 +275,10 @@ the Order 2 calculation.
 Running PandExo
 ~~~~~~~~~~~~~~~
 
-You have **four options** for running PandExo. All of them are accessed
-through attribute **jdi.run_pandexo**. See examples below.
+You have **four options** for running PandExo. All use
+**jdi.run_pandexo**.
 
-``jdi.run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,                             output_path=os.getcwd(), output_file = '', verbose=True)``
+``jdi.run_pandexo(exo, inst, param_space=0, param_range=0, save_file=True, output_path=None, output_file='', num_cores=None, verbose=True)``
 
 Option 1- Run single instrument mode, single planet
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -316,7 +304,7 @@ If you forget which instruments are available run
     exo_dict['star']['r_unit'] = 'R_sun'
     exo_dict['planet']['f_unit'] = 'rp^2/r*^2'
 
-    result = jdi.run_pandexo(exo_dict, ['MIRI LRS'])
+    result = jdi.run_pandexo(exo_dict, ['MIRI LRS'], save_file=False)
 
 Note, you can turn off print statements with ``verbose=False``
 
@@ -334,16 +322,15 @@ precision. Here the spectrum is binned to ``R=100`` for display.
 Option 2- Run single instrument mode (with user dict), single planet
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This is the same thing as option 1 but instead of feeding it a list of
-keys, you can feed it a instrument dictionary (this is for users who
-wanted to simulate something NOT pre defined within pandexo)
+This is the same as option 1, but it accepts an instrument dictionary so
+you can customize a supported configuration.
 
 .. code:: ipython3
 
     inst_dict = jdi.load_mode_dict('NIRSpec G140H')
-    #personalize subarray
+    # Personalize the subarray.
     inst_dict["configuration"]["detector"]["subarray"] = 'sub2048'
-    result = jdi.run_pandexo(exo_dict, inst_dict)
+    result = jdi.run_pandexo(exo_dict, inst_dict, save_file=False)
 
 Option 3- Run several modes, single planet
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -352,26 +339,25 @@ Use several modes from **print_instruments()** options.
 
 .. code:: ipython3
 
-    #choose select
+    # Choose selected modes.
     result = jdi.run_pandexo(exo_dict,['NIRSpec G140M','NIRSpec G235M','NIRSpec G395M'],
-                   output_file='three_nirspec_modes.p',verbose=True)
+                   save_file=False, verbose=True)
     #run all
     #result = jdi.run_pandexo(exo_dict, ['RUN ALL'], save_file = False)
 
 Option 4- Run single mode, several planet cases
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use a single mode from **print_instruments()** options. But explore
-parameter space with respect to **any** parameter in the exo dict. The
-example below uses a few planet radii so the notebook remains runnable
-without external model files.
+Use a single mode from **print_instruments()** and explore parameter
+space for **any** value in the exoplanet dictionary. The example below
+uses a few planet radii so the notebook remains runnable without
+external model files.
 
-You can loop through anything in the exoplanet dictionary. It will be
-planet, star or observation followed by whatever you want to loop
-through in that set.
+Use ``planet``, ``star``, or ``observation`` followed by the key to
+vary.
 
-i.e. planet+exopath, star+temp, star+metal, star+logg,
-observation+sat_level.. etc
+For example: ``planet+exopath``, ``star+temp``, ``star+metal``,
+``star+logg``, or ``observation+sat_level``.
 
 .. code:: ipython3
 

--- a/notebooks/JWST_Running_Pandexo.ipynb
+++ b/notebooks/JWST_Running_Pandexo.ipynb
@@ -35,7 +35,7 @@
    "source": [
     "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
-    "import pandexo.engine.justdoit as jdi # THIS IS THE HOLY GRAIL OF PANDEXO\n",
+    "import pandexo.engine.justdoit as jdi\n",
     "import pandexo.engine.justplotit as jpi\n",
     "import numpy as np\n",
     "import os\n",
@@ -100,7 +100,7 @@
     "exo_dict['observation']['sat_unit'] = '%'\n",
     "exo_dict['observation']['noccultations'] = 1 #number of transits\n",
     "exo_dict['observation']['R'] = None          #fixed binning. I usually suggest ZERO binning.. you can always bin later\n",
-    "                                             #without having to redo the calcualtion\n",
+    "                                             #without having to redo the calculation\n",
     "exo_dict['observation']['baseline_unit'] = 'total'  #Defines how you specify out of transit observing time\n",
     "                                                    #'frac' : fraction of time in transit versus out = in/out\n",
     "                                                    #'total' : total observing time (seconds)\n",
@@ -149,28 +149,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Let's create a little fake stellar input\n",
-    "\n",
-    "import scipy.constants as sc\n",
+    "# Create an arbitrary user-supplied stellar spectral shape. PandExo\n",
+    "# normalizes it to the magnitude and reference wavelength below.\n",
     "wl = np.linspace(0.5, 15, 3000)\n",
-    "nu = sc.c/(wl*1e-6)  # frequency in sec^-1\n",
-    "teff = 5500.0\n",
-    "planck_5500K = nu**3 / (np.exp(sc.h*nu/sc.k/teff) - 1)\n",
     "\n",
-    "#can either be dictionary input\n",
-    "starflux = {'f':planck_5500K, 'w':wl}\n",
-    "#or can be as a stellar file\n",
-    "#starflux = 'planck_5500K.dat'\n",
-    "#with open(starflux, 'w') as sf:\n",
-    "#    for w,f in zip(wl, planck_5500K):\n",
-    "#        sf.write(f'{w:.15f}   {f:.15e}\\n')\n",
+    "# A user spectrum can be supplied as a dictionary or a two-column file.\n",
+    "starflux = {'f': (wl / 1.25)**-2, 'w': wl}\n",
     "\n",
     "exo_dict['star']['type'] = 'user'\n",
     "exo_dict['star']['mag'] = 10.0              #magnitude of the system\n",
     "exo_dict['star']['ref_wave'] = 1.25\n",
     "exo_dict['star']['starpath'] = starflux\n",
     "exo_dict['star']['w_unit'] = 'um'\n",
-    "exo_dict['star']['f_unit'] = 'erg/cm2/s/Hz'"
+    "exo_dict['star']['f_unit'] = 'jy'"
    ]
   },
   {
@@ -197,14 +188,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exo_dict['planet']['type'] ='user'                       #tells pandexo you are uploading your own spectrum\n",
-    "exo_dict['planet']['exopath'] = 'wasp12b.txt'\n",
+    "exo_dict['planet']['type'] = 'user'                      # Upload a user spectrum.\n",
+    "wavelength = np.linspace(0.6, 5.3, 500)\n",
+    "spectrum = np.full_like(wavelength, 0.015)\n",
+    "exo_dict['planet']['exopath'] = {'f': spectrum, 'w': wavelength}\n",
     "\n",
-    "#or as a dictionary\n",
-    "#exo_dict['planet']['exopath'] = {'f':spectrum, 'w':wavelength}\n",
-    "\n",
-    "exo_dict['planet']['w_unit'] = 'cm'                      #other options include \"um\",\"nm\" ,\"Angs\", \"sec\" (for phase curves)\n",
-    "exo_dict['planet']['f_unit'] = 'rp^2/r*^2'               #other options are 'fp/f*'\n",
+    "exo_dict['planet']['w_unit'] = 'um'                      # Other options include nm, Angs, and sec (phase curves).\n",
+    "exo_dict['planet']['f_unit'] = 'rp^2/r*^2'               # The other option is fp/f*.\n",
     "exo_dict['planet']['transit_duration'] = 2.0*60.0*60.0   #transit duration\n",
     "exo_dict['planet']['td_unit'] = 's'                      #Any unit of time in accordance with astropy.units can be added"
    ]
@@ -241,8 +231,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3) Select from grid\n",
-    "NOTE: Currently only the fortney grid for hot Jupiters from Fortney+2010 is supported. Holler though, if you want another grid supported"
+    "#### 3) Select from a grid\n",
+    "Currently, PandExo supports the Fortney et al. (2010) hot-Jupiter grid."
    ]
   },
   {
@@ -305,10 +295,9 @@
    "source": [
     "inst_dict = jdi.load_mode_dict('NIRSpec G140H')\n",
     "\n",
-    "#loading in instrument dictionaries allow you to personalize some of\n",
-    "#the fields that are predefined in the templates. The templates have\n",
-    "#the subbarays with the lowest frame times and the readmodes with 1 frame per group.\n",
-    "#if that is not what you want. change these fields\n",
+    "# Loading an instrument dictionary lets you personalize template fields.\n",
+    "# Templates use subarrays with the lowest frame times and readout modes\n",
+    "# with one frame per group; change these fields when needed.\n",
     "\n",
     "#Try printing this out to get a feel for how it is structured:\n",
     "\n",
@@ -416,10 +405,10 @@
    "source": [
     "## Running PandExo\n",
     "\n",
-    "You have **four options** for running PandExo. All of them are accessed through attribute **jdi.run_pandexo**. See examples below. \n",
+    "You have **four options** for running PandExo. All use **jdi.run_pandexo**.\n",
     "\n",
-    "`    jdi.run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,\n",
-    "                            output_path=os.getcwd(), output_file = '', verbose=True)`\n",
+    "`jdi.run_pandexo(exo, inst, param_space=0, param_range=0, save_file=True,\n",
+    "output_path=None, output_file='', num_cores=None, verbose=True)`\n",
     "\n"
    ]
   },
@@ -458,7 +447,7 @@
     "exo_dict['star']['r_unit'] = 'R_sun'\n",
     "exo_dict['planet']['f_unit'] = 'rp^2/r*^2'\n",
     "\n",
-    "result = jdi.run_pandexo(exo_dict, ['MIRI LRS'])"
+    "result = jdi.run_pandexo(exo_dict, ['MIRI LRS'], save_file=False)"
    ]
   },
   {
@@ -491,7 +480,7 @@
    "metadata": {},
    "source": [
     "### Option 2- Run single instrument mode (with user dict), single planet\n",
-    "This is the same thing as option 1 but instead of feeding it a list of keys, you can feed it a instrument dictionary (this is for users who wanted to simulate something NOT pre defined within pandexo)"
+    "This is the same as option 1, but it accepts an instrument dictionary so you can customize a supported configuration."
    ]
   },
   {
@@ -501,9 +490,9 @@
    "outputs": [],
    "source": [
     "inst_dict = jdi.load_mode_dict('NIRSpec G140H')\n",
-    "#personalize subarray\n",
+    "# Personalize the subarray.\n",
     "inst_dict[\"configuration\"][\"detector\"][\"subarray\"] = 'sub2048'\n",
-    "result = jdi.run_pandexo(exo_dict, inst_dict)"
+    "result = jdi.run_pandexo(exo_dict, inst_dict, save_file=False)"
    ]
   },
   {
@@ -520,9 +509,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#choose select\n",
+    "# Choose selected modes.\n",
     "result = jdi.run_pandexo(exo_dict,['NIRSpec G140M','NIRSpec G235M','NIRSpec G395M'],\n",
-    "               output_file='three_nirspec_modes.p',verbose=True)\n",
+    "               save_file=False, verbose=True)\n",
     "#run all\n",
     "#result = jdi.run_pandexo(exo_dict, ['RUN ALL'], save_file = False)"
    ]
@@ -532,11 +521,11 @@
    "metadata": {},
    "source": [
     "### Option 4- Run single mode, several planet cases\n",
-    "Use a single mode from **print_instruments()** options. But explore parameter space with respect to **any** parameter in the exo dict. The example below uses a few planet radii so the notebook remains runnable without external model files.\n",
+    "Use a single mode from **print_instruments()** and explore parameter space for **any** value in the exoplanet dictionary. The example below uses a few planet radii so the notebook remains runnable without external model files.\n",
     "\n",
-    "You can loop through anything in the exoplanet dictionary. It will be planet, star or observation followed by whatever you want to loop through in that set. \n",
+    "Use ``planet``, ``star``, or ``observation`` followed by the key to vary.\n",
     "\n",
-    "i.e. planet+exopath, star+temp, star+metal, star+logg, observation+sat_level.. etc"
+    "For example: ``planet+exopath``, ``star+temp``, ``star+metal``, ``star+logg``, or ``observation+sat_level``."
    ]
   },
   {

--- a/pandexo/engine/justdoit.py
+++ b/pandexo/engine/justdoit.py
@@ -355,8 +355,17 @@ def run_inst_space(inst,exo, verbose=False):
     return {inst: wrapper({"pandeia_input": inst_dict , "pandexo_input":exo}, verbose=run_verbose)}
 
 
-def run_pandexo(exo, inst, param_space=0, param_range=0, save_file=True,
-                output_path=None, output_file='', num_cores=None, verbose=True):
+def run_pandexo(
+    exo,
+    inst,
+    param_space=0,
+    param_range=0,
+    save_file=True,
+    output_path=None,
+    output_file='',
+    num_cores=None,
+    verbose=True,
+):
     """Submits multiple runs of pandexo in parallel.
 
     Functionality: program contains functionality for running single or
@@ -366,42 +375,49 @@ def run_pandexo(exo, inst, param_space=0, param_range=0, save_file=True,
     ----------
     exo : dict
         exoplanet input dictionary
-    inst : dict or str or list of str
-        instrument input dictionary OR LIST of keys (for allowable keys see `print_instruments()`
+    inst : dict or list of str
+        Instrument input dictionary or a list of instrument keys. For allowable
+        keys, see ``print_instruments()``.
     param_space : str or 0
-        (Optional) Default is 0 = no exoplanet parameter space. To run through a parameter
-        specify which one need to specify two keys from exo dict with + in between.
-        i.e. observation+fraction
-        star+temp
-        planet+exopath
+        (Optional) Default is 0 = no exoplanet parameter space. To run through
+        a parameter, specify two exoplanet dictionary keys separated by ``+``;
+        for example, ``observation+fraction``, ``star+temp``, or
+        ``planet+exopath``.
     param_range : list of str or list of float
-        (Optional) Default = 0 An array or list over which to run the parameters space.
-        i.e. array of temperatures if running through stellar temp or
-        array of files if running through planet models. Must specify param_space
-        if using this.
+        (Optional) Default = 0. Array or list over which to run parameter
+        space, such as temperatures for ``star+temp`` or files for
+        ``planet+exopath``. Requires ``param_space``.
     save_file : bool
         (Optional) Default = True saves file, False does not
     output_path : str or path-like, optional
         Directory for saved output. Defaults to the current working directory
         when the function is called.
     output_file : str
-        (Optional) Default is "singlerun.p" for single runs, "param_space.p" for exo parameter runs
-        or "instrument_run.p" for instrument parameter space runs.
+        (Optional) Default is ``singlerun.p`` for single runs,
+        ``param_space.p`` for exoplanet parameter runs, or
+        ``instrument_run.p`` for instrument runs.
     num_cores : int, optional
         Number of parallel worker processes. Defaults to the CPU count when the
         function is called.
-    verbose : bool 
-        (Optional) For single runs, if false, it turns off all print statements. For parameter space 
-        runs it is defaulted to never print statements out.
+    verbose : bool
+        (Optional) Turns off print statements for single runs when false.
+        Parameter-space runs are quiet by default.
 
     Returns
     -------
     dict
-        For single run output will just be a single PandExo output dictionary
-        as described in the JWST Output Dictionary documentation.
-        For multiple runs the output will be organized into a list with each
-        a dictionary named by whatever you are looping through
-        i.e. [{'First temp': PandExoDict}, {'Second temp': PandExoDict}, etc..]
+        PandExo result for an instrument dictionary or a one-element list of
+        named instruments without a parameter range.
+    list of dict
+        Results for an exoplanet parameter-space run, multiple named
+        instruments, or ``['RUN ALL']``. Each element is a one-key dictionary
+        whose value is a PandExo result. Parameter-space keys are the basename
+        of each ``param_range`` value; instrument runs are keyed by instrument
+        name. List order matches ``param_range``, the supplied instrument list,
+        or the ``ALL`` instrument order, respectively.
+    None
+        Returned after printing input guidance when ``inst`` is neither a
+        dictionary nor a list.
 
     Example
     -------

--- a/pandexo/engine/justdoit.py
+++ b/pandexo/engine/justdoit.py
@@ -32,8 +32,6 @@ from astroquery.simbad import Simbad
 import astropy.units as u
 import copy
 
-user_cores = multiprocessing.cpu_count()
-
 ALL = {"WFC3 G141":False,
        "MIRI LRS":False,
        "NIRISS SOSS":False,
@@ -78,7 +76,7 @@ def getStarName(planet_name):
     # Return trimmed string:
     return star_name.strip()
 
-def load_exo_dict(planet_name=None,pl_kwargs={}):
+def load_exo_dict(planet_name=None, pl_kwargs=None):
     """Loads in empty exoplanet dictionary for pandexo input
 
     Loads in empty exoplanet dictionary so that the user can manually edit different planet
@@ -103,8 +101,11 @@ def load_exo_dict(planet_name=None,pl_kwargs={}):
     >>> exo_dict = load_exo_dict()
     >>> exo_dict['planet']['transit_duration'] = 2*60*60 #2 hours
     """
+    if pl_kwargs is None:
+        pl_kwargs = {}
+
     with open(os.path.join(os.path.dirname(__file__), "reference",
-                               "exo_input.json")) as data_file:
+                           "exo_input.json")) as data_file:
         pandexo_input = json.load(data_file)
 
     if not isinstance(planet_name, type(None)):
@@ -212,7 +213,7 @@ def load_mode_dict(inst):
     Returns
     -------
     dict
-        Filled out template of instrument dictionary, which can be editted before
+        Filled out template of instrument dictionary, which can be edited before
         running to PandExo (not required).
 
     Example
@@ -239,10 +240,10 @@ def get_thruput(inst, niriss=1, nirspec='f100lp', wmin='default', wmax='default'
         (Optional) for NIRSpec G140M/H there are two available filters (f100lp and f070lp)
         if you are selecting G140M or G140H, this allows you to pick which one
     wmin : str / float
-        (Optional) minimum wavlength to compute PCE across, 'default' will use
+        (Optional) minimum wavelength to compute PCE across; 'default' uses
         values from Pandeia.
     wmax : str / float
-        (Optional) maximum wavlength to compute PCE across, 'default' will use
+        (Optional) maximum wavelength to compute PCE across; 'default' uses
         values from Pandeia.
     Returns
     -------
@@ -251,7 +252,7 @@ def get_thruput(inst, niriss=1, nirspec='f100lp', wmin='default', wmax='default'
 
     Example
     -------
-    >>> thru_dict = get_thruput('NIRISS SOSS_Or1')
+    >>> thru_dict = get_thruput('NIRISS SOSS', niriss=1)
     """
 
     #pull correct dictionary
@@ -354,8 +355,8 @@ def run_inst_space(inst,exo, verbose=False):
     return {inst: wrapper({"pandeia_input": inst_dict , "pandexo_input":exo}, verbose=run_verbose)}
 
 
-def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
-                            output_path=os.getcwd(), output_file = '',num_cores=user_cores, verbose=True):
+def run_pandexo(exo, inst, param_space=0, param_range=0, save_file=True,
+                output_path=None, output_file='', num_cores=None, verbose=True):
     """Submits multiple runs of pandexo in parallel.
 
     Functionality: program contains functionality for running single or
@@ -380,11 +381,15 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         if using this.
     save_file : bool
         (Optional) Default = True saves file, False does not
-    output_path : str
-        (Optional) Defaults to current working directory
+    output_path : str or path-like, optional
+        Directory for saved output. Defaults to the current working directory
+        when the function is called.
     output_file : str
         (Optional) Default is "singlerun.p" for single runs, "param_space.p" for exo parameter runs
         or "instrument_run.p" for instrument parameter space runs.
+    num_cores : int, optional
+        Number of parallel worker processes. Defaults to the CPU count when the
+        function is called.
     verbose : bool 
         (Optional) For single runs, if false, it turns off all print statements. For parameter space 
         runs it is defaulted to never print statements out.
@@ -413,6 +418,11 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
     >>> a = run_pandexo(exo_dict, ['NIRSpec G395M'],
             param_space ='star+mag',param_range = np.linspace(6,10,5))
     """
+
+    if output_path is None:
+        output_path = os.getcwd()
+    if num_cores is None:
+        num_cores = multiprocessing.cpu_count()
 
     #single instrument mode with dictionary input OR single planet
     if type(inst) == dict:
@@ -494,7 +504,7 @@ def run_pandexo(exo, inst, param_space = 0, param_range = 0,save_file = True,
         return results
 
 def subarrays(inst):
-  """function to show availalble subarrays and their times (in secons)
+  """Show available subarrays and their frame times in seconds.
 
   Parameters
   ----------
@@ -538,7 +548,7 @@ def dispersers(inst):
   Returns
   -------
   list
-    lsit with available dispersers
+    List of available dispersers.
   """
   print("Dispersers field stored in inst_dict['configuration']['instrument']['disperser']")
   if inst.lower() == 'niriss':
@@ -553,7 +563,7 @@ def dispersers(inst):
     raise Exception("Only instruments are niriss, nirspec, miri, nircam. Pick one.")
 
 def filters(inst):
-    """Function to show availalbe filters
+    """Show available filters.
 
   Parameters
   ----------
@@ -563,7 +573,7 @@ def filters(inst):
   Returns
   -------
   list
-    list with availalbe filters
+    List of available filters.
   """
     print("Filters field stored in inst_dict['configuration']['instrument']['filter']")
 
@@ -582,10 +592,10 @@ def filters(inst):
 def grid_options(grid = 'fortney'):
     """Function to show available grid options
 
-    PandExo now supports various grid options. Currently, the only one that is availalbe
+    PandExo now supports various grid options. Currently, the only one that is available
     is the Fortney grid for giant planets. We will be implementing others, as they
     become available. It will become increasingly difficult for users to see what
-    options are availalbe to them. This function should guide users to choose
+    options are available to them. This function should guide users to choose
     the grid that best fits their needs.
 
     Parameters

--- a/pandexo/engine/justplotit.py
+++ b/pandexo/engine/justplotit.py
@@ -384,7 +384,7 @@ def jwst_1d_flux(result_dict, plot=True, output_file= 'flux.html'):
         make sure to restructure the input as a list of dictionaries without they key words
         that run_pandexo assigns.
     plot : bool
-        (Optional) True renders plot, Flase does not. Default=True
+        (Optional) True renders a plot; False does not. Default=True
     output_file : str
         (Optional) Default = 'flux.html'
     Return
@@ -428,7 +428,7 @@ def jwst_1d_snr(result_dict, plot=True, output_file='snr.html'):
         make sure to restructure the input as a list of dictionaries without they key words
         that run_pandexo assigns.
     plot : bool
-        (Optional) True renders plot, Flase does not. Default=True
+        (Optional) True renders a plot; False does not. Default=True
     output_file : str
         (Optional) Default = 'snr.html'
 
@@ -471,7 +471,7 @@ def jwst_1d_bkg(result_dict, plot=True, output_file='bkg.html'):
         make sure to restructure the input as a list of dictionaries without they key words
         that run_pandexo assigns.
     plot : bool
-        (Optional) True renders plot, Flase does not. Default=True
+        (Optional) True renders a plot; False does not. Default=True
     output_file : str
         (Optional) Default = bkt.html
 
@@ -512,7 +512,7 @@ def jwst_noise(result_dict, plot=True, output_file= 'noise.html'):
         make sure to restructure the input as a list of dictionaries without they key words
         that run_pandexo assigns.
     plot : bool
-        (Optional) True renders plot, Flase does not. Default=True
+        (Optional) True renders a plot; False does not. Default=True
     output_file : str
         (Optional) Default = 'noise.html'
     Return
@@ -559,7 +559,7 @@ def jwst_2d_det(result_dict, plot=True, output_file='det2d.html'):
         that run_pandexo assigns.
 
     plot : bool
-        (Optional) True renders plot, Flase does not. Default=True
+        (Optional) True renders a plot; False does not. Default=True
     output_file : str
         (Optional) Default = 'det2d.html'
 
@@ -610,7 +610,7 @@ def jwst_2d_sat(result_dict, plot=True, output_file='sat2d.html'):
         that run_pandexo assigns.
 
     plot : bool
-        (Optional) True renders plot, Flase does not. Default=True
+        (Optional) True renders a plot; False does not. Default=True
     output_file : str
         (Optional) Default = 'sat2d.html'
 

--- a/pandexo/engine/run_online.py
+++ b/pandexo/engine/run_online.py
@@ -939,7 +939,6 @@ class CalculationNewHSTHandler(BaseHandler):
         pandata['strategy']['targetFluence'] = float(self.get_argument("targetFluence"))
 
         #import pickle as pk
-        #a = pk.load(open('/Users/natashabatalha/Desktop/JWST/testing/ui.pk','rb'))
         #pandata = a['pandeia_input']
         #exodata  = a['pandexo_input']
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pandexo.engine.justdoit as jdi
 
 
@@ -7,3 +9,37 @@ def test_load_exo_dict_contains_required_sections():
     assert "observation" in exo_dict
     assert "star" in exo_dict
     assert "planet" in exo_dict
+
+
+def test_public_defaults_are_resolved_at_call_time():
+    load_exo_signature = inspect.signature(jdi.load_exo_dict)
+    run_signature = inspect.signature(jdi.run_pandexo)
+
+    assert load_exo_signature.parameters["pl_kwargs"].default is None
+    assert run_signature.parameters["output_path"].default is None
+    assert run_signature.parameters["num_cores"].default is None
+
+
+def test_run_pandexo_uses_the_call_time_working_directory(
+    monkeypatch, tmp_path
+):
+    """The public default must not capture the directory at import time."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(jdi, "wrapper", lambda *args, **kwargs: {"ok": True})
+
+    result = jdi.run_pandexo({}, {}, verbose=False)
+
+    assert result == {"ok": True}
+    assert (tmp_path / "singlerun.p").is_file()
+
+
+def test_run_pandexo_honors_an_explicit_output_directory(
+    monkeypatch, tmp_path
+):
+    output_path = tmp_path / "results"
+    output_path.mkdir()
+    monkeypatch.setattr(jdi, "wrapper", lambda *args, **kwargs: {"ok": True})
+
+    jdi.run_pandexo({}, {}, output_path=output_path, verbose=False)
+
+    assert (output_path / "singlerun.p").is_file()

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -3,6 +3,16 @@ import inspect
 import pandexo.engine.justdoit as jdi
 
 
+class _ImmediateParallel:
+    """Execute joblib delayed calls synchronously for branch tests."""
+
+    def __init__(self, n_jobs):
+        self.n_jobs = n_jobs
+
+    def __call__(self, tasks):
+        return [function(*args, **kwargs) for function, args, kwargs in tasks]
+
+
 def test_load_exo_dict_contains_required_sections():
     exo_dict = jdi.load_exo_dict()
 
@@ -43,3 +53,70 @@ def test_run_pandexo_honors_an_explicit_output_directory(
     jdi.run_pandexo({}, {}, output_path=output_path, verbose=False)
 
     assert (output_path / "singlerun.p").is_file()
+
+
+def test_run_pandexo_returns_a_dict_for_single_named_instrument(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        jdi, "load_mode_dict", lambda instrument: {"name": instrument}
+    )
+    monkeypatch.setattr(
+        jdi, "wrapper", lambda *args, **kwargs: {"single": True}
+    )
+
+    result = jdi.run_pandexo({}, ["MIRI LRS"], save_file=False, verbose=False)
+
+    assert result == {"single": True}
+
+
+def test_run_pandexo_returns_keyed_lists_for_multi_run_branches(
+    monkeypatch,
+):
+    monkeypatch.setattr(jdi, "Parallel", _ImmediateParallel)
+    monkeypatch.setattr(
+        jdi,
+        "run_inst_space",
+        lambda instrument, exo, verbose=False: {
+            instrument: {"instrument": instrument}
+        },
+    )
+    monkeypatch.setattr(
+        jdi,
+        "run_param_space",
+        lambda value, exo, inst, param_space, verbose=False: {
+            str(value): {"parameter": value}
+        },
+    )
+    monkeypatch.setattr(jdi, "ALL", {"First": False, "Second": False})
+
+    selected = jdi.run_pandexo(
+        {},
+        ["NIRSpec G140M", "NIRSpec G235M"],
+        save_file=False,
+        verbose=False,
+    )
+    all_modes = jdi.run_pandexo(
+        {}, ["RUN ALL"], save_file=False, verbose=False
+    )
+    parameter_space = jdi.run_pandexo(
+        {},
+        ["NIRSpec G140M"],
+        param_space="star+temp",
+        param_range=[5000, 5500],
+        save_file=False,
+        verbose=False,
+    )
+
+    assert selected == [
+        {"NIRSpec G140M": {"instrument": "NIRSpec G140M"}},
+        {"NIRSpec G235M": {"instrument": "NIRSpec G235M"}},
+    ]
+    assert all_modes == [
+        {"First": {"instrument": "First"}},
+        {"Second": {"instrument": "Second"}},
+    ]
+    assert parameter_space == [
+        {"5000": {"parameter": 5000}},
+        {"5500": {"parameter": 5500}},
+    ]


### PR DESCRIPTION
## Summary

* make Unix and Windows installation guidance self-contained, including:

  * Pandeia, PSF, PHOENIX, and normalization reference-data setup
  * correct `PYSYN_CDBS` directory layout
  * robust creation and population of the Windows `comp` and `mtab` directories
  * persistent and current-session environment variables
  * separate validation paths for pip installations and source checkouts
* refresh the documentation landing page, navigation labels, API organization, JWST configuration and output references, tutorials, captions, and accessibility text
* make tutorial examples self-contained and prevent example runs from unintentionally overwriting saved output
* improve saved-result documentation, including a trusted-source warning and example for loading PandExo pickle files
* resolve public defaults at call time in `run_pandexo`, remove the mutable `load_exo_dict` default, and remove developer-specific paths from generated API signatures
* document the actual `run_pandexo` return structures for single-instrument, multi-instrument, `RUN ALL`, and parameter-space calculations
* add lightweight tests covering public defaults, output-directory behavior, and representative `run_pandexo` return containers without requiring full Pandeia simulations
* add scheduled and manually triggered external-link validation while retaining strict pull-request HTML builds

## Validation

* `python -m pytest tests/test_import.py -q`
* `python docs/generate_tutorial_rst.py --check`
* `flake8 tests/test_import.py`
* `sphinx-build -E -W --keep-going -b html docs docs/_build/html`
* `sphinx-build -E -W --keep-going -b linkcheck docs docs/_build/linkcheck`

The clean HTML build and link check pass. The only link-check note is the expected redirect of the Fortney archive link to Box.

## Deployment

This PR intentionally updates the source documentation only.

After it merges:

1. Check out the merged `master` branch.
2. regenerate the documentation into `docs/_build/html`
3. open a separate pull request replacing the contents of `gh-pages` with the clean generated HTML
4. preserve the existing `.nojekyll` file
5. visually inspect the deployed documentation before the PandExo 2026.7 PyPI release is announced