### PR TITLE
Clarify reference-data setup and add required Vega spectrum

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -40,7 +40,7 @@ to the appropriate file, replacing the example paths:
     export PSF_DIR=/path/to/pandeia_psfs-2026.7-jwst
 
 These are example paths. Set each variable to the directory that was actually
-created when you extracted the archive; pre-release archives may include a
+created when you extracted the archive; archives may sometimes include a
 suffix such as ``rc1`` in that directory name.
 
 Source the startup file to make the changes available in your current terminal,
@@ -91,7 +91,7 @@ from the normalization archive:
     rsync -a "$NORMALIZATION_TRDS/comp/" "$PYSYN_CDBS/comp/"
     rsync -a "$NORMALIZATION_TRDS/mtab/" "$PYSYN_CDBS/mtab/"
 
-Download the much smaller `Vega CALSPEC file
+Also download the small `Vega CALSPEC file
 <https://archive.stsci.edu/hlsps/reference-atlases/cdbs/calspec/alpha_lyr_stis_011.fits>`_
 separately and save it at the location expected by stsynphot:
 
@@ -101,7 +101,7 @@ separately and save it at the location expected by stsynphot:
     curl -L https://archive.stsci.edu/hlsps/reference-atlases/cdbs/calspec/alpha_lyr_stis_011.fits -o "$PYSYN_CDBS/calspec/alpha_lyr_stis_011.fits"
 
 This single file is sufficient for PandExo; downloading the full multi-gigabyte
-``synphot6`` archive is not required.
+``synphot6`` archive is not required for PandExo use.
 
 The ``$PYSYN_CDBS`` directory should now contain ``calspec``, ``comp``,
 ``grid``, and ``mtab`` (among other synphot directories). Verify that layout

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,6 +39,10 @@ to the appropriate file, replacing the example paths:
     export pandeia_refdata=/path/to/pandeia_data-2026.7-jwst
     export PSF_DIR=/path/to/pandeia_psfs-2026.7-jwst
 
+These are example paths. Set each variable to the directory that was actually
+created when you extracted the archive; pre-release archives may include a
+suffix such as ``rc1`` in that directory name.
+
 Source the startup file to make the changes available in your current terminal,
 for example:
 
@@ -68,7 +72,8 @@ file again:
 Normalization Files  
 ```````````````````
 PandExo also needs the STScI/CDBS-style throughput files used for J/H/K
-normalization bandpasses.
+normalization bandpasses and the Vega calibration spectrum used to convert
+those magnitudes to fluxes.
 
 `Download the file here <https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v11_sed.tar>`_
 
@@ -86,9 +91,21 @@ from the normalization archive:
     rsync -a "$NORMALIZATION_TRDS/comp/" "$PYSYN_CDBS/comp/"
     rsync -a "$NORMALIZATION_TRDS/mtab/" "$PYSYN_CDBS/mtab/"
 
-The ``$PYSYN_CDBS`` directory should now contain ``comp``, ``grid``, and
-``mtab`` (among other synphot directories). Verify that layout and the files
-PandExo uses for J/H/K normalization and PHOENIX spectra:
+Download the much smaller `Vega CALSPEC file
+<https://archive.stsci.edu/hlsps/reference-atlases/cdbs/calspec/alpha_lyr_stis_011.fits>`_
+separately and save it at the location expected by stsynphot:
+
+.. code-block:: bash
+
+    mkdir -p "$PYSYN_CDBS/calspec"
+    curl -L https://archive.stsci.edu/hlsps/reference-atlases/cdbs/calspec/alpha_lyr_stis_011.fits -o "$PYSYN_CDBS/calspec/alpha_lyr_stis_011.fits"
+
+This single file is sufficient for PandExo; downloading the full multi-gigabyte
+``synphot6`` archive is not required.
+
+The ``$PYSYN_CDBS`` directory should now contain ``calspec``, ``comp``,
+``grid``, and ``mtab`` (among other synphot directories). Verify that layout
+and the files PandExo uses for J/H/K normalization and PHOENIX spectra:
 
 .. code-block:: bash
 
@@ -96,23 +113,8 @@ PandExo uses for J/H/K normalization and PHOENIX spectra:
     ls "$PYSYN_CDBS/comp/nonhst/bessell_j_003_syn.fits"
     ls "$PYSYN_CDBS/comp/nonhst/bessell_h_004_syn.fits"
     ls "$PYSYN_CDBS/comp/nonhst/bessell_k_003_syn.fits"
+    ls "$PYSYN_CDBS/calspec/alpha_lyr_stis_011.fits"
     ls "$PYSYN_CDBS/grid/phoenix/catalog.fits"
-
-Verify the complete reference-data setup with:
-
-.. code-block:: bash
-
-    python -c "import pandeia.engine; pandeia.engine.pandeia_version()"
-
-If properly installed and configured, it should show the matching versions and
-stellar reference-data directory, like this:
-
-.. code-block:: text
-
-    Pandeia Engine version:  2026.7
-    Pandeia RefData version: 2026.7
-    Pandeia PSFs version:    2026.7
-    Synphot Data:            /path/to/grp/redcat/trds
 
 Fortney+ 2010 Planet Grid (Optional)
 ````````````````````````````````````
@@ -164,6 +166,23 @@ getting started:
 
 Final Test for Success
 ======================
+
+Now that PandExo and its Pandeia dependency are installed, verify the complete
+reference-data setup:
+
+.. code-block:: bash
+
+    python -c "import pandeia.engine; pandeia.engine.pandeia_version()"
+
+If properly installed and configured, it should show the matching versions and
+stellar reference-data directory, like this:
+
+.. code-block:: text
+
+    Pandeia Engine version:  2026.7
+    Pandeia RefData version: 2026.7
+    Pandeia PSFs version:    2026.7
+    Synphot Data:            /path/to/grp/redcat/trds
 
 For a normal pip installation, run this installed-package smoke test. It loads
 PandExo's bundled NIRSpec configuration and does not download data, start the

--- a/docs/installation_windows.rst
+++ b/docs/installation_windows.rst
@@ -44,12 +44,17 @@ files are available here:
 - `Pandeia PSFs v2026p7 JWST <https://stsci.app.box.com/v/pandeia-psfs-v2026p7-jwst>`_
 - `PHOENIX stellar reference atlas <https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_pheonix-models_multi_v3_synphot5.tar>`_
 - `Normalization bandpasses <https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v11_sed.tar>`_
+- `Vega CALSPEC file <https://archive.stsci.edu/hlsps/reference-atlases/cdbs/calspec/alpha_lyr_stis_011.fits>`_
 
 The stellar and normalization archives both extract a ``grp/redcat/trds``
 tree. ``PYSYN_CDBS`` must name the PHOENIX archive's ``trds`` directory, not
 its parent ``grp`` directory. Copy the normalization archive's ``comp`` and
 ``mtab`` *contents* into the matching directories under that same
 ``PYSYN_CDBS`` directory. Do not nest another ``grp/redcat/trds`` tree there.
+Save the Vega file as
+``PYSYN_CDBS\calspec\alpha_lyr_stis_011.fits``. This single file is sufficient
+for PandExo; downloading the full multi-gigabyte ``synphot6`` archive is not
+required.
 
 Step 5: Set Reference-Data Variables
 `````````````````````````````````````
@@ -67,6 +72,10 @@ persistent values are loaded automatically.
     [Environment]::SetEnvironmentVariable('pandeia_refdata', $env:pandeia_refdata, 'User')
     [Environment]::SetEnvironmentVariable('PSF_DIR', $env:PSF_DIR, 'User')
     [Environment]::SetEnvironmentVariable('PYSYN_CDBS', $env:PYSYN_CDBS, 'User')
+
+These are example paths. Set each variable to the directory that was actually
+created when you extracted the archive; pre-release archives may include a
+suffix such as ``rc1`` in that directory name.
 
 Copy the normalization ``comp`` and ``mtab`` contents into ``PYSYN_CDBS``. In
 this example, ``$normalizationTrds`` is the ``trds`` directory extracted from
@@ -86,6 +95,15 @@ the normalization archive:
         "$normalizationTrds\mtab\*" `
         "$env:PYSYN_CDBS\mtab\"
 
+Create the CALSPEC directory, then copy the downloaded Vega file into it:
+
+.. code-block:: powershell
+
+    New-Item -ItemType Directory -Force "$env:PYSYN_CDBS\calspec" | Out-Null
+    Copy-Item -Force `
+        "$HOME\Downloads\alpha_lyr_stis_011.fits" `
+        "$env:PYSYN_CDBS\calspec\alpha_lyr_stis_011.fits"
+
 Verify the current terminal's variables and required files:
 
 .. code-block:: powershell
@@ -99,6 +117,7 @@ Verify the current terminal's variables and required files:
     Test-Path "$env:PYSYN_CDBS\grid"
     Test-Path "$env:PYSYN_CDBS\mtab"
     Test-Path "$env:PYSYN_CDBS\comp\nonhst\bessell_j_003_syn.fits"
+    Test-Path "$env:PYSYN_CDBS\calspec\alpha_lyr_stis_011.fits"
     Test-Path "$env:PYSYN_CDBS\grid\phoenix\catalog.fits"
     (Get-ChildItem "$env:PYSYN_CDBS\mtab" -File -Recurse | Measure-Object).Count -gt 0
 

--- a/docs/installation_windows.rst
+++ b/docs/installation_windows.rst
@@ -74,7 +74,7 @@ persistent values are loaded automatically.
     [Environment]::SetEnvironmentVariable('PYSYN_CDBS', $env:PYSYN_CDBS, 'User')
 
 These are example paths. Set each variable to the directory that was actually
-created when you extracted the archive; pre-release archives may include a
+created when you extracted the archive; archives may sometimes include a
 suffix such as ``rc1`` in that directory name.
 
 Copy the normalization ``comp`` and ``mtab`` contents into ``PYSYN_CDBS``. In


### PR DESCRIPTION
## Summary

Addresses the installation-documentation issues reported in #120.

- Clarifies that `pandeia_refdata` and `PSF_DIR` must point to the directories actually created during extraction, including suffixes such as `rc1`.
- Moves the Pandeia version/reference-data check until after PandExo and its dependencies have been installed.
- Documents the required `alpha_lyr_stis_011.fits` Vega calibration spectrum and its expected location under `$PYSYN_CDBS/calspec`.
- Clarifies that users do not need to download the full multi-gigabyte `synphot6` archive.
- Adds equivalent Vega setup and validation instructions to the Windows installation guide.

Closes #120